### PR TITLE
added new metrics to quantile scoring: bias, sharpness, calibration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 in `eval_forecasts`
 - included support for passing down arguments to lower-level functions in 
 `eval_forecasts`
+- included support for three new metrics to score quantiles with 
+`eval_forecasts`: bias, sharpness and calibration
 
 ### Package updates
 - example data now has a horizon column to illustrate the use of grouping

--- a/R/eval_forecasts.R
+++ b/R/eval_forecasts.R
@@ -222,7 +222,7 @@ eval_forecasts <- function(data,
     # only possible if median forecast exists
     if (0 %in% unique(res$range)) {
       bias <- res[range == 0,
-                  .(bias = 1 - 2 * mean(true_values > unique(lower))),
+                  .(bias = 1 - 2 * mean(true_values > lower)),
                   by = by]
 
       res <-  merge(res, bias, by = by)


### PR DESCRIPTION
added 3 new metrics to `eval_forecasts`
- sharpness as percentage of true values that fall in a given interval range
- bias as transformed percentage of true values above and below the median
- sharpness as the mean width of the 50% interval range