### PR TITLE
Fix bug in metrics selection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scoringutils
 Title: Utilities for Scoring and Assessing Predictions
-Version: 0.1.7.1
+Version: 0.1.7.2
 Language: en-GB
 Authors@R: c(
     person(given = "Nikos",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## scoringutils 0.1.7.2
+### Package updates
+- minor bug fixes (previously, 'interval_score' needed to be among the 
+selected metrics)
+
 ## scoringutils 0.1.7
 ## Feature updates
 - added a function, `pairwise_comparison()` that runs pairwise comparisons 

--- a/R/eval_forecasts_binary.R
+++ b/R/eval_forecasts_binary.R
@@ -40,9 +40,9 @@ eval_forecasts_binary <- function(data,
     }
 
     # summarise by taking the mean over all relevant columns
-    res <- data[, lapply(.SD, mean, na.rm = TRUE),
-                .SDcols = colnames(res) %like% "brier",
-                by = summarise_by]
+    res <- res[, lapply(.SD, mean, na.rm = TRUE),
+               .SDcols = colnames(res) %like% "brier",
+               by = summarise_by]
 
   }
 }

--- a/R/eval_forecasts_continuous_integer.R
+++ b/R/eval_forecasts_continuous_integer.R
@@ -135,7 +135,7 @@ eval_forecasts_sample <- function(data,
     }
   }
 
-  res <- data
+  res <- data.table::copy(data)
 
   # make scores unique to avoid redundancy.
   res <- res[, lapply(.SD, unique),

--- a/R/eval_forecasts_quantile.R
+++ b/R/eval_forecasts_quantile.R
@@ -52,27 +52,31 @@ eval_forecasts_quantile <- function(data,
   count_median_twice <- interval_score_arguments$count_median_twice
   interval_score_arguments$count_median_twice <- NULL
 
+  # set up results data.table that will then be modified throughout ------------
+  res <- data.table::copy(data)
+
   # calculate scores on range format -------------------------------------------
   if ("interval_score" %in% metrics) {
     # compute separate results if desired
     if (interval_score_arguments$separate_results) {
-      res <- data[, c("interval_score",
-                      "sharpness",
-                      "underprediction",
-                      "overprediction") := do.call(scoringutils::interval_score,
-                                                   c(list(true_value,
-                                                          lower,
-                                                          upper,
-                                                          range),
-                                                     interval_score_arguments))]
+      res <- res[, c("interval_score",
+                     "sharpness",
+                     "underprediction",
+                     "overprediction") := do.call(scoringutils::interval_score,
+                                                  c(list(true_value,
+                                                         lower,
+                                                         upper,
+                                                         range),
+                                                    interval_score_arguments))]
     } else {
-      res <- data[, c("interval_score") := do.call(scoringutils::interval_score,
-                                                   c(list(true_value,
-                                                          lower,
-                                                          upper,
-                                                          range),
-                                                     interval_score_arguments))]
+      res <- res[, c("interval_score") := do.call(scoringutils::interval_score,
+                                                  c(list(true_value,
+                                                         lower,
+                                                         upper,
+                                                         range),
+                                                    interval_score_arguments))]
     }
+    # res[, .(unlist(interval_score)), by = setdiff(colnames(res), "interval_score")]
   }
 
   # compute coverage for every single observation
@@ -182,7 +186,7 @@ eval_forecasts_quantile <- function(data,
   if (!("range" %in% summarise_by)) {
     res[, c("coverage") := NULL]
   }
-  if (!("quantile" %in% summarise_by)) {
+  if (!("quantile" %in% summarise_by) & "quantile_coverage" %in% names(res)) {
     res[, c("quantile_coverage") := NULL]
   }
 

--- a/tests/testthat/test-eval_forecasts.R
+++ b/tests/testthat/test-eval_forecasts.R
@@ -68,6 +68,22 @@ test_that("all quantile and range formats yield the same result", {
   expect_equal(sort(eval1$aem), sort(ae))
 })
 
+test_that("function produces output even if only some metrics are chosen", {
+  range_example_wide <- data.table::setDT(scoringutils::range_example_data_wide)
+  range_example <- scoringutils::range_wide_to_long(range_example_wide)
+
+  eval <- scoringutils::eval_forecasts(range_example,
+                                       summarise_by = c("model", "range"),
+                                       metrics = "coverage",
+                                       sd = TRUE)
+
+  expect_equal(nrow(eval) > 1,
+               TRUE)
+})
+
+
+
+
 
 # test integer and continuous case ---------------------------------------------
 test_that("function produces output for a continuous format case", {

--- a/tests/testthat/test-interval_score.R
+++ b/tests/testthat/test-interval_score.R
@@ -114,7 +114,8 @@ test_that("wis works, 2 intervals and median", {
       (quantiles[, 4] - quantiles[, 2])*(alpha2/2) + c(0, 1-(-15), 22-3)
   )
 
-  expect_identical(eval$interval_score, expected)
+  expect_equal(as.numeric(eval$interval_score),
+               as.numeric(expected))
 })
 
 


### PR DESCRIPTION
This PR
- fixes a bug where not selecting 'interval_score' as a metric when using quantile data resulted in an error
- fixes an unrelated small bug where for binary scores, the wrong data.frame was used to summarise scores
- creates a new unit test for the bug fix
- updates the version number and news file