### PR TITLE
Create pkgdown reference index

### DIFF
--- a/R/eval_forecasts_helper.R
+++ b/R/eval_forecasts_helper.R
@@ -9,6 +9,8 @@
 #' @param by grouping variable in `eval_forecasts()
 #'
 #' @return `data.table` with quantiles added
+#'
+#' @keywords internal
 add_quantiles <- function(dt, varnames, quantiles, by) {
   # make sure that the desired varnames are actually present
   varnames <- intersect(varnames, colnames(dt))
@@ -31,6 +33,8 @@ add_quantiles <- function(dt, varnames, quantiles, by) {
 #' @param by grouping variable in `eval_forecasts()
 #' @importFrom data.table `%like%`
 #' @return `data.table` with sd added
+#'
+#' @keywords internal
 add_sd <- function(dt, varnames, by) {
   # make sure that the desired varnames are actually present
   varnames <- intersect(varnames, colnames(dt))

--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -113,6 +113,8 @@ pairwise_comparison <- function(scores,
 #' @inheritParams eval_forecasts
 #' @param unsummarised_scores unsummarised scores to be passed from
 #' \code{\link{eval_forecasts}}
+#'
+#' @keywords internal
 
 add_rel_skill_to_eval_forecasts <- function(unsummarised_scores,
                                             rel_skill_metric,

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,6 +7,8 @@
 #' @param ... The variables to check
 #' @return The function returns `NULL`, but throws an error if the variable is
 #' missing.
+#'
+#' @keywords internal
 check_not_null <- function(...) {
   vars <- list(...)
   varnames <- names(vars)
@@ -36,6 +38,8 @@ check_not_null <- function(...) {
 #'
 #' @return The function returns `NULL`, but throws an error if variable lengths
 #' differ
+#'
+#' @keywords internal
 check_equal_length <- function(...,
                                one_allowed = TRUE) {
   vars <- list(...)
@@ -64,6 +68,8 @@ check_equal_length <- function(...,
 #'
 #' @param x numeric vector of values for which to calculate the geometric mean
 #' @return the geometric mean of the values in `x`
+#'
+#' @keywords internal
 geom_mean_helper <- function(x) {
   geom_mean <- exp(mean(log(x[!is.na(x)])))
   return(geom_mean)
@@ -149,6 +155,8 @@ list_of_avail_metrics <- function() {
 #' individual list element of `list`
 #' @return A list with the extracted element from every sublist
 #' missing.
+#'
+#' @keywords internal
 extract_from_list <- function(list, what) {
   out <- lapply(list,
                 FUN = function(list_element) {
@@ -170,6 +178,8 @@ extract_from_list <- function(list, what) {
 #' @param optional A list of optional settings to override defaults
 #' @return A list
 #' @export
+#'
+#' @keywords internal
 update_list <- function(defaults = list(), optional = list()) {
   if (length(optional) != 0) {
     defaults <- defaults[setdiff(names(defaults), names(optional))]
@@ -228,6 +238,8 @@ permutation_test <- function(scores1,
 #' @param cols_to_delete character vector with names of columns to be deleted
 #' @importFrom data.table as.data.table
 #' @return A data.table
+#'
+#' @keywords internal
 delete_columns <- function(df, cols_to_delete) {
   df <- data.table::as.data.table(df)
   delete_columns <- names(df)[names(df) %in% cols_to_delete]

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,55 @@
+reference:
+        - title: Package documentation
+          contents:
+                - scoringutils
+        - title: Evaluation functions
+          contents:
+                - compare_two_models
+                - eval_forecasts
+                - eval_forecasts_binary
+                - eval_forecasts_sample
+                - pairwise_comparison
+                - pairwise_comparison_one_group
+        - title: Scoring functions
+          contents:
+                - abs_error
+                - ae_median_quantile
+                - ae_median_sample
+                - bias
+                - brier_score
+                - crps
+                - dss
+                - interval_score
+                - logs
+                - mse
+                - pit
+                - pit_df
+                - pit_df_fast
+                - quantile_bias
+                - sharpness
+        - title: Data wrangling helpers
+          contents:
+                - ends_with("to_long")
+                - ends_with("to_wide")
+                - ends_with("to_quantile")
+                - ends_with("to_range")
+                - ends_with("to_range_long")
+                - merge_pred_and_obs
+        - title: Plotting helpers
+          contents:
+                - starts_with("plot_")
+                - ends_with("_plot")
+                - hist_PIT
+                - hist_PIT_quantile
+                - interval_coverage
+                - quantile_coverage
+                - score_table
+                - score_heatmap
+                - show_avail_forecasts
+                - wis_components
+        - title: Internal functions
+          contents:
+                - has_keyword("internal")
+        - title: Example data
+          contents:
+                - has_keyword("datasets")

--- a/man/add_quantiles.Rd
+++ b/man/add_quantiles.Rd
@@ -21,3 +21,4 @@ add_quantiles(dt, varnames, quantiles, by)
 \description{
 Helper function used within eval_forecasts
 }
+\keyword{internal}

--- a/man/add_rel_skill_to_eval_forecasts.Rd
+++ b/man/add_rel_skill_to_eval_forecasts.Rd
@@ -50,3 +50,4 @@ make pairwise comparisons from within that function. It uses the
 Essentially, it wraps \code{\link{pairwise_comparison}} and deals with the specifics
 necessary to work with \code{\link{eval_forecasts}}.
 }
+\keyword{internal}

--- a/man/add_sd.Rd
+++ b/man/add_sd.Rd
@@ -19,3 +19,4 @@ add_sd(dt, varnames, by)
 \description{
 Helper function used within eval_forecasts
 }
+\keyword{internal}

--- a/man/check_equal_length.Rd
+++ b/man/check_equal_length.Rd
@@ -18,3 +18,4 @@ differ
 \description{
 Check whether variables all have the same length
 }
+\keyword{internal}

--- a/man/check_not_null.Rd
+++ b/man/check_not_null.Rd
@@ -18,3 +18,4 @@ Check whether a certain variable is not `NULL` and return the name of that
 variable and the function call where the variable is missing. This function
 is a helper function that should only be called within other functions
 }
+\keyword{internal}

--- a/man/delete_columns.Rd
+++ b/man/delete_columns.Rd
@@ -18,3 +18,4 @@ A data.table
 take a vector of column names and delete the columns if they
 are present in the data.table
 }
+\keyword{internal}

--- a/man/extract_from_list.Rd
+++ b/man/extract_from_list.Rd
@@ -19,3 +19,4 @@ missing.
 \description{
 Extract corresponding elements from a list of lists.
 }
+\keyword{internal}

--- a/man/geom_mean_helper.Rd
+++ b/man/geom_mean_helper.Rd
@@ -15,3 +15,4 @@ the geometric mean of the values in `x`
 \description{
 Calculate Geometric Mean
 }
+\keyword{internal}

--- a/man/update_list.Rd
+++ b/man/update_list.Rd
@@ -19,3 +19,4 @@ A list
 Used to handle updating settings in a list. For example when making
 changes to `interval_score_arguments` in `eval_forecasts()`
 }
+\keyword{internal}


### PR DESCRIPTION
scoringutils exports a lot of functions and while I was trying to learn more about the package functionality, it was difficult to create mental categories of which function serves which purpose. In this PR, I make these categories explicit by creating a reference index for the pkgdown website.

I can revisit this PR as much as necessary, e.g., by adding a short description for each category. I also see that you are probably in the process of submitting to CRAN so feel free to delay merging this PR as you might not want to introduce extra sources of potential issues at the last minute. 

For reference, here is the relevant pkgdown help page where you can see all the options for the reference index: https://pkgdown.r-lib.org/reference/build_reference.html

A screenshot of the output:

![Screen Shot 2021-07-20 at 07 18 07-fullpage](https://user-images.githubusercontent.com/10783929/126278880-5a5daf14-f433-4335-8d23-1721fe62d4f4.png)
