### PR TITLE
Explicitly load metrics data

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -88,7 +88,7 @@ globalVariables(c(
 #' @keywords info
 
 available_metrics <- function() {
-  return(unique(metrics$Name))
+  return(unique(scoringutils::metrics$Name))
 }
 
 #' @title Simple permutation test


### PR DESCRIPTION
This PR fixes #227 by explicitly loading the metrics data set. We now get the following in a clean R session which replicates the behaviour when `scoringutils` is loaded.

```
scoringutils::score(scoringutils::example_quantile)                                                                    
The following messages were produced when checking inputs:
1.  144 values for `prediction` are NA in the data provided and the corresponding rows were removed. This may indicate a problem if unexpected.
       location target_end_date target_type location_name forecast_date                 model horizon range interval_score
    1:       DE      2021-05-08       Cases       Germany    2021-05-03 EuroCOVIDhub-baseline       1     0       25620.00
    2:       DE      2021-05-08       Cases       Germany    2021-05-03 EuroCOVIDhub-baseline       1    10       25599.50
    3:       DE      2021-05-08       Cases       Germany    2021-05-03 EuroCOVIDhub-baseline       1    10       25599.50
    4:       DE      2021-05-08       Cases       Germany    2021-05-03 EuroCOVIDhub-baseline       1    20       25481.00
    5:       DE      2021-05-08       Cases       Germany    2021-05-03 EuroCOVIDhub-baseline       1    20       25481.00
   ---                                                                                                                    
20397:       IT      2021-07-24      Deaths         Italy    2021-07-12  epiforecasts-EpiNow2       2    90          21.50
20398:       IT      2021-07-24      Deaths         Italy    2021-07-12  epiforecasts-EpiNow2       2    95          13.90
20399:       IT      2021-07-24      Deaths         Italy    2021-07-12  epiforecasts-EpiNow2       2    95          13.90
20400:       IT      2021-07-24      Deaths         Italy    2021-07-12  epiforecasts-EpiNow2       2    98           6.71
20401:       IT      2021-07-24      Deaths         Italy    2021-07-12  epiforecasts-EpiNow2       2    98           6.71
       dispersion underprediction overprediction coverage coverage_deviation bias quantile ae_median quantile_coverage
    1:       0.00               0          25620        0               0.00 0.95    0.500     25620              TRUE
    2:     184.50               0          25415        0              -0.10 0.95    0.450     25620              TRUE
    3:     184.50               0          25415        0              -0.10 0.95    0.550     25620              TRUE
    4:     556.00               0          24925        0              -0.20 0.95    0.400     25620              TRUE
    5:     556.00               0          24925        0              -0.20 0.95    0.600     25620              TRUE
   ---                                                                                                                
20397:      21.50               0              0        1               0.10 0.90    0.950       108              TRUE
20398:      13.90               0              0        1               0.05 0.90    0.025       108             FALSE
20399:      13.90               0              0        1               0.05 0.90    0.975       108              TRUE
20400:       6.71               0              0        1               0.02 0.90    0.010       108             FALSE
20401:       6.71               0              0        1               0.02 0.90    0.990       108              TRUE
