### PR TITLE
Fix 223 issue with add_coverage

### DIFF
--- a/R/summarise_scores.R
+++ b/R/summarise_scores.R
@@ -92,7 +92,7 @@ summarise_scores <- function(scores,
   # takes the mean over ranges and quantiles first, if neither range nor
   # quantile are in `by`. Reason to do this is that summaries may be
   # inaccurate if we treat individual quantiles as independent forecasts
-  scores <- scores[, lapply(.SD, mean, ...),
+  scores <- scores[, lapply(.SD, base::mean, ...),
     by = c(unique(c(forecast_unit, by))),
     .SDcols = colnames(scores) %like% cols_to_summarise
   ]


### PR DESCRIPTION
When by is not null we saw an issue with `add_coverage` highlighted in #223. This appears to be caused by an issue in the `data.table` code. Dropping into debug changing the call to the `mean` function to be explict (i.e `base::mean`) fixes the issue on my system. If this also causes no reversions on CI etc I'd suggest merging as aa bug fix for bleeding edge users.  I can't identify any changes in `data.table` that would lead to this change so still hypothetical that this was the system level difference. 