### PR TITLE
Fix requirements table in getting-started vignette

### DIFF
--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -37,8 +37,9 @@ requirements <- data.table(
     "quantile-based", "sample-based", "binary", "pairwise-comparisons"
   ),
   `Required columns` = c(
-    "'true_value', 'prediction', 'quantile'", "'true_value', 'prediction',
-    'sample'", "'true_value', 'prediction'", "additionally a column 'model'"
+    "'true_value', 'prediction', 'quantile'",
+    "'true_value', 'prediction', 'sample'", "'true_value', 'prediction'",
+    "additionally a column 'model'"
   )
 )
 kable(requirements)


### PR DESCRIPTION
The line break in the data.table is interpreted as a line break (\n) in the string itself, leading the table to be formatted incorrectly.