### PR TITLE
don't error if baseline model is not present

### DIFF
--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -229,6 +229,9 @@ pairwise_comparison_one_group <- function(scores,
 
   if (!is.null(baseline)) {
     baseline_theta <- unique(result[model == baseline, ]$theta)
+    if (length(baseline_theta) == 0) {
+      stop("Baseline model ", baseline, " missing.")
+    }
     result[, rel_to_baseline := theta / baseline_theta]
   }
 

--- a/tests/testthat/test-pairwise_comparison.R
+++ b/tests/testthat/test-pairwise_comparison.R
@@ -267,3 +267,9 @@ test_that("pairwise_comparison() works inside and outside of score()", {
     sort(eval2$relative_skill)
   )
 })
+
+test_that("pairwise_comparison() realises when there is no baseline model", {
+  expect_error(pairwise_comparison(eval_with_baseline,
+    baseline = "missing_model"
+  ), "missing")
+})


### PR DESCRIPTION
avoids the pairwise comparison erroring if the specified baseline model is not present in the data (happening [in some instance](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/actions/runs/3354890469/jobs/5558750446) at the European Forecast Hub).

It could also make sense to throw an informative error. The function can still compute useable pairwise comparisons so I thought a warning might be more appropriate here.