### PR TITLE
simplify plot_pairwise_comparison()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ A minor update to the package with some bug fixes and minor changes.
 - Removed the on attach message which warned of breaking changes in `1.0.0`.
 - Renamed the `metric` argument of `summarise_scores()` to `relative_skill_metric`. This argument is now deprecated and will be removed in a future version of the package. Please use the new argument instead.
 - Updated the documentation for `score()` and related functions to make the soft requirement for a `model` column in the input data more explicit.
+- simplified the function `plot_pairwise_comparison()` which now only supports plotting mean score ratios or p-values and removed the hybrid option to print both at the same time. 
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@ A minor update to the package with some bug fixes and minor changes.
 - Removed the on attach message which warned of breaking changes in `1.0.0`.
 - Renamed the `metric` argument of `summarise_scores()` to `relative_skill_metric`. This argument is now deprecated and will be removed in a future version of the package. Please use the new argument instead.
 - Updated the documentation for `score()` and related functions to make the soft requirement for a `model` column in the input data more explicit.
-- simplified the function `plot_pairwise_comparison()` which now only supports plotting mean score ratios or p-values and removed the hybrid option to print both at the same time. 
+- Simplified the function `plot_pairwise_comparison()` which now only supports plotting mean score ratios or p-values and removed the hybrid option to print both at the same time. 
 
 ## Bug fixes
 

--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -35,21 +35,12 @@
 #' @author Johannes Bracher, \email{johannes.bracher@@kit.edu}
 #' @keywords scoring
 #' @examples
-#' df <- data.frame(
-#'   model = rep(c("model1", "model2", "model3"), each = 10),
-#'   date = as.Date("2020-01-01") + rep(1:5, each = 2),
-#'   location = c(1, 2),
-#'   interval_score = (abs(rnorm(30))),
-#'   ae_median = (abs(rnorm(30)))
-#' )
+#' scores <- score(example_quantile)
+#' pairwise <- pairwise_comparison(scores, by = "target_type")
 #'
-#' res <- pairwise_comparison(df,
-#'   baseline = "model1"
-#' )
-#' plot_pairwise_comparison(res)
-#'
-#' eval <- score(example_quantile)
-#' pairwise_comparison(eval, by = c("model"))
+#' library(ggplot2)
+#' plot_pairwise_comparison(pairwise, type = "mean_score_ratio") +
+#'   facet_wrap(~target_type)
 
 pairwise_comparison <- function(scores,
                                 by = c("model"),

--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -39,7 +39,7 @@
 #' pairwise <- pairwise_comparison(scores, by = "target_type")
 #'
 #' library(ggplot2)
-#' plot_pairwise_comparison(pairwise, type = "mean_score_ratio") +
+#' plot_pairwise_comparison(pairwise, type = "mean_scores_ratio") +
 #'   facet_wrap(~target_type)
 
 pairwise_comparison <- function(scores,

--- a/R/plot.R
+++ b/R/plot.R
@@ -690,8 +690,8 @@ plot_quantile_coverage <- function(scores,
 #' @param comparison_result A data.frame as produced by
 #' [pairwise_comparison()]
 #' @param type character vector of length one that is either
-#'  "mean_scores_ratio", "pval", or "together". This denotes whether to
-#' visualise the ratio or the p-value of the pairwise comparison or both.
+#'  "mean_scores_ratio" or "pval". This denotes whether to
+#' visualise the ratio or the p-value of the pairwise comparison.
 #' Default is "mean_scores_ratio".
 #' @importFrom ggplot2 ggplot aes geom_tile geom_text labs coord_cartesian
 #' scale_fill_gradient2 theme_light element_text

--- a/R/plot.R
+++ b/R/plot.R
@@ -704,7 +704,7 @@ plot_quantile_coverage <- function(scores,
 #' library(ggplot2)
 #' scores <- score(example_quantile)
 #' pairwise <- pairwise_comparison(scores, by = "target_type")
-#' plot_pairwise_comparison(pairwise, type = "mean_score_ratio") +
+#' plot_pairwise_comparison(pairwise, type = "mean_scores_ratio") +
 #'   facet_wrap(~target_type)
 
 plot_pairwise_comparison <- function(comparison_result,

--- a/man/pairwise_comparison.Rd
+++ b/man/pairwise_comparison.Rd
@@ -47,21 +47,12 @@ The implementation of the permutation test follows the function
 Andrea Riebler and Michaela Paul.
 }
 \examples{
-df <- data.frame(
-  model = rep(c("model1", "model2", "model3"), each = 10),
-  date = as.Date("2020-01-01") + rep(1:5, each = 2),
-  location = c(1, 2),
-  interval_score = (abs(rnorm(30))),
-  ae_median = (abs(rnorm(30)))
-)
+scores <- score(example_quantile)
+pairwise <- pairwise_comparison(scores, by = "target_type")
 
-res <- pairwise_comparison(df,
-  baseline = "model1"
-)
-plot_pairwise_comparison(res)
-
-eval <- score(example_quantile)
-pairwise_comparison(eval, by = c("model"))
+library(ggplot2)
+plot_pairwise_comparison(pairwise, type = "mean_score_ratio") +
+  facet_wrap(~target_type)
 }
 \author{
 Nikos Bosse \email{nikosbosse@gmail.com}

--- a/man/pairwise_comparison.Rd
+++ b/man/pairwise_comparison.Rd
@@ -51,7 +51,7 @@ scores <- score(example_quantile)
 pairwise <- pairwise_comparison(scores, by = "target_type")
 
 library(ggplot2)
-plot_pairwise_comparison(pairwise, type = "mean_score_ratio") +
+plot_pairwise_comparison(pairwise, type = "mean_scores_ratio") +
   facet_wrap(~target_type)
 }
 \author{

--- a/man/plot_pairwise_comparison.Rd
+++ b/man/plot_pairwise_comparison.Rd
@@ -6,8 +6,7 @@
 \usage{
 plot_pairwise_comparison(
   comparison_result,
-  type = c("mean_scores_ratio", "pval", "together"),
-  smaller_is_good = TRUE
+  type = c("mean_scores_ratio", "pval")
 )
 }
 \arguments{
@@ -15,14 +14,9 @@ plot_pairwise_comparison(
 \code{\link[=pairwise_comparison]{pairwise_comparison()}}}
 
 \item{type}{character vector of length one that is either
-"mean_scores_ratio", "pval", or "together". This denotes whether to
-visualise the ratio or the p-value of the pairwise comparison or both.
+"mean_scores_ratio" or "pval". This denotes whether to
+visualise the ratio or the p-value of the pairwise comparison.
 Default is "mean_scores_ratio".}
-
-\item{smaller_is_good}{logical (default is \code{TRUE}) that indicates whether
-smaller or larger values are to be interpreted as 'good' (as you could just
-invert the mean scores ratio). This option is not supported when type =
-"pval"}
 }
 \description{
 Creates a heatmap of the ratios or pvalues from a pairwise comparison
@@ -30,15 +24,8 @@ between models
 }
 \examples{
 library(ggplot2)
-df <- data.frame(
-  model = rep(c("model1", "model2", "model3"), each = 10),
-  id = rep(1:10),
-  interval_score = abs(rnorm(30, mean = rep(c(1, 1.3, 2), each = 10))),
-  ae_median = (abs(rnorm(30)))
-)
-
 scores <- score(example_quantile)
 pairwise <- pairwise_comparison(scores, by = "target_type")
-plot_pairwise_comparison(pairwise) +
+plot_pairwise_comparison(pairwise, type = "mean_score_ratio") +
   facet_wrap(~target_type)
 }

--- a/man/plot_pairwise_comparison.Rd
+++ b/man/plot_pairwise_comparison.Rd
@@ -26,6 +26,6 @@ between models
 library(ggplot2)
 scores <- score(example_quantile)
 pairwise <- pairwise_comparison(scores, by = "target_type")
-plot_pairwise_comparison(pairwise, type = "mean_score_ratio") +
+plot_pairwise_comparison(pairwise, type = "mean_scores_ratio") +
   facet_wrap(~target_type)
 }

--- a/tests/testthat/test-plot_pairwise_comparison.R
+++ b/tests/testthat/test-plot_pairwise_comparison.R
@@ -17,39 +17,3 @@ test_that("plot_pairwise_comparison() works when showing p values", {
   skip_on_cran()
   vdiffr::expect_doppelganger("plot_pairwise_comparison_pval", p)
 })
-
-test_that("plot_pairwise_comparison() works when everything", {
-  p <- plot_pairwise_comparison(pairwise, type = "together") +
-    ggplot2::facet_wrap(~target_type)
-  expect_s3_class(p, "ggplot")
-  skip_on_cran()
-  vdiffr::expect_doppelganger("plot_pairwise_together", p)
-})
-
-test_that("plot_pairwise_comparison() works as expected when smaller is bad", {
-  p <- plot_pairwise_comparison(pairwise, smaller_is_good = FALSE) +
-    ggplot2::facet_wrap(~target_type)
-  expect_s3_class(p, "ggplot")
-  skip_on_cran()
-  vdiffr::expect_doppelganger("plot_pairwise_comparison_sib", p)
-})
-
-test_that("plot_pairwise_comparison() doesn't work when showing p values and
-           smaller is bad", {
-  expect_error(
-    plot_pairwise_comparison(
-      pairwise, type = "pval", smaller_is_good = FALSE
-    ) +
-    ggplot2::facet_wrap(~target_type)
-  )
-})
-
-test_that("plot_pairwise_comparison() works when everything is shown together and smaller is bad", {
-  p <- plot_pairwise_comparison(
-    pairwise, type = "together", smaller_is_good = FALSE
-  ) +
-    ggplot2::facet_wrap(~target_type)
-  expect_s3_class(p, "ggplot")
-  skip_on_cran()
-  vdiffr::expect_doppelganger("plot_pairwise_together_sib", p)
-})


### PR DESCRIPTION
Simplify the function by removing the option to plot both pvalues and mean score ratios together. 