### PR TITLE
Make boolean vector explicitly numeric when computing interval scores

### DIFF
--- a/R/interval_score.R
+++ b/R/interval_score.R
@@ -114,8 +114,10 @@ interval_score <- function(true_values,
 
   # calculate three components of WIS
   dispersion <- (upper - lower)
-  overprediction <- 2 / alpha * (lower - true_values) * (true_values < lower)
-  underprediction <- 2 / alpha * (true_values - upper) * (true_values > upper)
+  overprediction <-
+    2 / alpha * (lower - true_values) * as.numeric(true_values < lower)
+  underprediction <-
+    2 / alpha * (true_values - upper) * as.numeric(true_values > upper)
 
   if (weigh) {
     dispersion <- dispersion * alpha / 2


### PR DESCRIPTION
Addresses #273 
Ultimately the issue seems to be outside scoringutils, however adding `as.numeric` to the code doesn't add much complexity and just makes explicit what is happening implicitly anyway. 
Discussion here: https://github.com/epinowcast/epinowcast/issues/198