### PR TITLE
Issue 272: Add an across argument to summarise_scores()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ inst/manuscript/manuscript_files/
 docs
 ..bfg-report/
 .DS_Store
+.vscode

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scoringutils
 Title: Utilities for Scoring and Assessing Predictions
-Version: 1.1.5
+Version: 1.1.6
 Language: en-GB
 Authors@R: c(
     person(given = "Nikos",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# scoringutils 1.1.6
+
+## Feature updates
+- Added a new argument, `across`, to `summarise_scores()`. This argument allows the user to summarise scores across different forecast units as an alternative to specifying `by`. See the documentation for `summarise_scores()` for more details and an example use case.
+
 # scoringutils 1.1.5
 
 ## Feature updates

--- a/R/summarise_scores.R
+++ b/R/summarise_scores.R
@@ -15,9 +15,11 @@
 #' forecast per day, location and model). Adding additional, unrelated, columns
 #' may alter results in an unpredictable way.
 #' @param across character vector with column names from the vector of variables
-#' that define the *unit of a single forecast* (see above) to summarise across.
-#' If `NULL` (default), then `by` will be used or inferred internally if also
-#' not specified. Only one of `across` and `by`  may be used at a time.
+#' that define the *unit of a single forecast* (see above) to summarise scores
+#' across (meaning that the specified columns will be dropped). This is an
+#' , and in essentially a reverse of, specifying `by`. If `NULL` (default),
+#' then `by` will be used or inferred internally if also not specified. Only
+#' one of `across` and `by`  may be used at a time.
 #' @param fun a function used for summarising scores. Default is `mean`.
 #' @param relative_skill logical, whether or not to compute relative
 #' performance between models based on pairwise comparisons.

--- a/R/summarise_scores.R
+++ b/R/summarise_scores.R
@@ -17,9 +17,9 @@
 #' @param across character vector with column names from the vector of variables
 #' that define the *unit of a single forecast* (see above) to summarise scores
 #' across (meaning that the specified columns will be dropped). This is an
-#' , and in essentially a reverse of, specifying `by`. If `NULL` (default),
-#' then `by` will be used or inferred internally if also not specified. Only
-#' one of `across` and `by`  may be used at a time.
+#' alternative to specifying `by` directly. If `NULL` (default), then `by` will
+#' be used or inferred internally if also not specified. Only  one of `across` 
+#' and `by`  may be used at a time.
 #' @param fun a function used for summarising scores. Default is `mean`.
 #' @param relative_skill logical, whether or not to compute relative
 #' performance between models based on pairwise comparisons.

--- a/R/summarise_scores.R
+++ b/R/summarise_scores.R
@@ -113,6 +113,11 @@ summarise_scores <- function(scores,
 
   # if across is provided, remove from by
   if (!is.null(across)) {
+    if (length(intersect(by, across)) == 0) {
+      stop(
+        "The columns specified in 'across' must be a subset of the columns ",
+        "that define the forecast unit. Please check your input and try again.")
+    }
     by <- setdiff(by, across)
   }
 

--- a/R/summarise_scores.R
+++ b/R/summarise_scores.R
@@ -115,10 +115,13 @@ summarise_scores <- function(scores,
 
   # if across is provided, remove from by
   if (!is.null(across)) {
-    if (length(intersect(by, across)) == 0) {
+    if (!all(across %in% by)) {
       stop(
         "The columns specified in 'across' must be a subset of the columns ",
-        "that define the forecast unit. Please check your input and try again.")
+        "that define the forecast unit (possible options are ",
+        toString(by),
+        "). Please check your input and try again."
+      )
     }
     by <- setdiff(by, across)
   }

--- a/R/summarise_scores.R
+++ b/R/summarise_scores.R
@@ -16,8 +16,8 @@
 #' may alter results in an unpredictable way.
 #' @param across character vector with column names from the vector of variables
 #' that define the *unit of a single forecast* (see above) to summarise across.
-#' If `NULL` (default), then `by`` will be used. Only one of `across` and `by` 
-#' may be used at a time.
+#' If `NULL` (default), then `by` will be used or inferred internally if also
+#' not specified. Only one of `across` and `by`  may be used at a time.
 #' @param fun a function used for summarising scores. Default is `mean`.
 #' @param relative_skill logical, whether or not to compute relative
 #' performance between models based on pairwise comparisons.

--- a/man/summarise_scores.Rd
+++ b/man/summarise_scores.Rd
@@ -44,9 +44,11 @@ forecast per day, location and model). Adding additional, unrelated, columns
 may alter results in an unpredictable way.}
 
 \item{across}{character vector with column names from the vector of variables
-that define the \emph{unit of a single forecast} (see above) to summarise across.
-If \code{NULL} (default), then \code{by} will be used or inferred internally if also
-not specified. Only one of \code{across} and \code{by}  may be used at a time.}
+that define the \emph{unit of a single forecast} (see above) to summarise scores
+across (meaning that the specified columns will be dropped). This is an
+, and in essentially a reverse of, specifying \code{by}. If \code{NULL} (default),
+then \code{by} will be used or inferred internally if also not specified. Only
+one of \code{across} and \code{by}  may be used at a time.}
 
 \item{fun}{a function used for summarising scores. Default is \code{mean}.}
 

--- a/man/summarise_scores.Rd
+++ b/man/summarise_scores.Rd
@@ -45,8 +45,8 @@ may alter results in an unpredictable way.}
 
 \item{across}{character vector with column names from the vector of variables
 that define the \emph{unit of a single forecast} (see above) to summarise across.
-If \code{NULL} (default), then \verb{by`` will be used. Only one of }across\code{and}by`
-may be used at a time.}
+If \code{NULL} (default), then \code{by} will be used or inferred internally if also
+not specified. Only one of \code{across} and \code{by}  may be used at a time.}
 
 \item{fun}{a function used for summarising scores. Default is \code{mean}.}
 

--- a/man/summarise_scores.Rd
+++ b/man/summarise_scores.Rd
@@ -8,6 +8,7 @@
 summarise_scores(
   scores,
   by = NULL,
+  across = NULL,
   fun = mean,
   relative_skill = FALSE,
   relative_skill_metric = "auto",
@@ -19,6 +20,7 @@ summarise_scores(
 summarize_scores(
   scores,
   by = NULL,
+  across = NULL,
   fun = mean,
   relative_skill = FALSE,
   relative_skill_metric = "auto",
@@ -40,6 +42,11 @@ input data that do not correspond to a metric produced by \code{\link[=score]{sc
 indicate indicate a grouping of forecasts (for example there may be one
 forecast per day, location and model). Adding additional, unrelated, columns
 may alter results in an unpredictable way.}
+
+\item{across}{character vector with column names from the vector of variables
+that define the \emph{unit of a single forecast} (see above) to summarise across.
+If \code{NULL} (default), then \verb{by`` will be used. Only one of }across\code{and}by`
+may be used at a time.}
 
 \item{fun}{a function used for summarising scores. Default is \code{mean}.}
 
@@ -88,6 +95,11 @@ summarise_scores(scores,by = "model")
 
 # get scores by model and target type
 summarise_scores(scores, by = c("model", "target_type"))
+
+# Get scores summarised across horizon, forecast date, and target end date
+summarise_scores(
+ scores, across = c("horizon", "forecast_date", "target_end_date")
+)
 
 # get standard deviation
 summarise_scores(scores, by = "model", fun = sd)

--- a/man/summarise_scores.Rd
+++ b/man/summarise_scores.Rd
@@ -46,9 +46,9 @@ may alter results in an unpredictable way.}
 \item{across}{character vector with column names from the vector of variables
 that define the \emph{unit of a single forecast} (see above) to summarise scores
 across (meaning that the specified columns will be dropped). This is an
-, and in essentially a reverse of, specifying \code{by}. If \code{NULL} (default),
-then \code{by} will be used or inferred internally if also not specified. Only
-one of \code{across} and \code{by}  may be used at a time.}
+alternative to specifying \code{by} directly. If \code{NULL} (default), then \code{by} will
+be used or inferred internally if also not specified. Only  one of \code{across}
+and \code{by}  may be used at a time.}
 
 \item{fun}{a function used for summarising scores. Default is \code{mean}.}
 

--- a/tests/testthat/test-summarise_scores.R
+++ b/tests/testthat/test-summarise_scores.R
@@ -99,6 +99,12 @@ test_that("summarise_scores() across argument works as expected", {
     ),
     regexp = "You cannot specify both"
   )
+  expect_error( 
+    summarise_scores(
+      scores, across = "horizons"
+    ),
+    regexp = "The columns specified in 'across' must be a subset "
+  )
   expect_equal(
     summarise_scores(
       scores, across = c("horizon", "model", "forecast_date", "target_end_date")

--- a/tests/testthat/test-summarise_scores.R
+++ b/tests/testthat/test-summarise_scores.R
@@ -88,3 +88,23 @@ test_that("summarise_scores() metric is deprecated", {
     )
   )  
 })
+
+test_that("summarise_scores() across argument works as expected", {
+  ex <- data.table::copy(example_quantile)
+  scores <- suppressMessages(score(ex))[, location_name := NULL]
+
+  expect_error(
+    summarise_scores(
+      scores, by = "model", across = "horizon"
+    ),
+    regexp = "You cannot specify both"
+  )
+  expect_equal(
+    summarise_scores(
+      scores, across = c("horizon", "model", "forecast_date", "target_end_date")
+    ),
+    summarise_scores(
+      scores, by = c("location", "target_type")
+    )
+  )
+})

--- a/tests/testthat/test-summarise_scores.R
+++ b/tests/testthat/test-summarise_scores.R
@@ -105,6 +105,12 @@ test_that("summarise_scores() across argument works as expected", {
     ),
     regexp = "The columns specified in 'across' must be a subset "
   )
+  expect_error(
+    summarise_scores(
+      scores, across = c("horizon", "horizons"),
+    ),
+    regexp = "The columns specified in 'across' must be a subset"
+  )
   expect_equal(
     summarise_scores(
       scores, across = c("horizon", "model", "forecast_date", "target_end_date")


### PR DESCRIPTION
This PR closes #272 by implementing an `across` argument to `summarise_scores()`. 

It also: 

- Updates the release version by one minor release (in line with other recent PRs)
- Adds a news item for this change
- Adds an example to the `summarise_scores()` documentation for this new argument. 
- Adds tests that check the equivalence of this approach as well as checking it errors when expected.

Note that because of the multiple duplicate variables in the example data `across` isn't actually as useful as you might imagine (i.e. because `target_end_date` and `horizon` define the same thing). 