### PR TITLE
Scoringutils review customisable scores

### DIFF
--- a/R/brier_score.R
+++ b/R/brier_score.R
@@ -22,6 +22,7 @@
 #' all values equal to either 0 or 1
 #' @param predictions A vector with a predicted probability
 #' that true_value = 1.
+#' @param ... additional arguments (not currently used)
 #' @return A numeric value with the Brier Score, i.e. the mean squared
 #' error of the given probability forecasts
 #' @export
@@ -33,7 +34,7 @@
 #' brier_score(true_values, predictions)
 #' @keywords metric
 
-brier_score <- function(true_values, predictions) {
+brier_score <- function(true_values, predictions, ...) {
   check_true_values(true_values, type = "binary")
   check_predictions(predictions, true_values, type = "binary")
 

--- a/R/log_score.R
+++ b/R/log_score.R
@@ -24,7 +24,7 @@
 #' predictions <- runif(n = 30, min = 0, max = 1)
 
 #' logs_binary(true_values, predictions)
-logs_binary <- function(true_values, predictions) {
+logs_binary <- function(true_values, predictions, ...) {
   check_true_values(true_values, type = "binary")
   check_predictions(predictions, true_values, type = "binary")
 

--- a/R/score.R
+++ b/R/score.R
@@ -134,7 +134,8 @@ score <- function(data,
     scores <- score_binary(
       data = data,
       forecast_unit = forecast_unit,
-      metrics = metrics
+      metrics = metrics,
+      ...
     )
   }
 

--- a/R/score_binary.R
+++ b/R/score_binary.R
@@ -30,17 +30,27 @@ score_binary <- function(data,
   }
   metrics <- metrics[sapply(metrics, is.function)]
 
+  # fix names if there are none provided
+  # todo
+
   # need to check the functions used here
   # i.e. check the function has the relevant arguments.
 
 
-  lapply(seq_along(metrics), function(x, ...) {
-    metric_name <- names(metrics[x])
-    fun <- metrics[[x]]
+  lapply(seq_along(metrics), function(function_to_call, ...) {
+    metric_name <- names(metrics[function_to_call])
+    fun <- metrics[[function_to_call]]
 
-    data[, (metric_name) := fun(true_value, prediction, ...)]
+    fun_accepts_ellipsis <- any(names(formals(fun)) == "...")
+
+    if (fun_accepts_ellipsis) {
+      data[, (metric_name) := fun(true_value, prediction, ...)]
+    } else {
+      data[, (metric_name) := fun(true_value, prediction)]
+    }
+
     return()
-  })
+  }, ...)
 
   return(data[])
 }

--- a/R/score_binary.R
+++ b/R/score_binary.R
@@ -15,30 +15,30 @@
 
 score_binary <- function(data,
                          forecast_unit,
-                         metrics) {
+                         metrics, ...) {
 
   # get a list of the functions to be applied.
   # this should be done by some helper function / more elegantly
   metrics <- as.list(metrics)
   if ("brier_score" %in% metrics) {
     names(metrics)[metrics == "brier_score"] <- "brier_score"
-    metrics[["brier_score"]] <- list(brier_score)
+    metrics["brier_score"] <- list(brier_score)
   }
   if ("log_score" %in% metrics) {
     names(metrics)[metrics == "log_score"] <- "log_score"
     metrics["log_score"] <- list(logs_binary)
   }
-  metrics <- metrics[!is.na(names(metrics))]
+  metrics <- metrics[sapply(metrics, is.function)]
 
   # need to check the functions used here
   # i.e. check the function has the relevant arguments.
 
 
-  lapply(seq_along(metrics), function(x) {
+  lapply(seq_along(metrics), function(x, ...) {
     metric_name <- names(metrics[x])
     fun <- metrics[[x]]
 
-    data[, (metric_name) := fun(true_value, prediction)]
+    data[, (metric_name) := fun(true_value, prediction, ...)]
     return()
   })
 

--- a/R/score_binary.R
+++ b/R/score_binary.R
@@ -16,17 +16,31 @@
 score_binary <- function(data,
                          forecast_unit,
                          metrics) {
-  if ("brier_score" %in% metrics) {
-    data[, "brier_score" := brier_score(true_value, prediction),
-      by = forecast_unit
-    ]
-  }
 
-  if ("log_score" %in% metrics) {
-    data[, "log_score" := logs_binary(true_value, prediction),
-      by = forecast_unit
-    ]
+  # get a list of the functions to be applied.
+  # this should be done by some helper function / more elegantly
+  metrics <- as.list(metrics)
+  if ("brier_score" %in% metrics) {
+    names(metrics)[metrics == "brier_score"] <- "brier_score"
+    metrics[["brier_score"]] <- list(brier_score)
   }
+  if ("log_score" %in% metrics) {
+    names(metrics)[metrics == "log_score"] <- "log_score"
+    metrics["log_score"] <- list(logs_binary)
+  }
+  metrics <- metrics[!is.na(names(metrics))]
+
+  # need to check the functions used here
+  # i.e. check the function has the relevant arguments.
+
+
+  lapply(seq_along(metrics), function(x) {
+    metric_name <- names(metrics[x])
+    fun <- metrics[[x]]
+
+    data[, (metric_name) := fun(true_value, prediction)]
+    return()
+  })
 
   return(data[])
 }

--- a/R/score_binary.R
+++ b/R/score_binary.R
@@ -30,9 +30,6 @@ score_binary <- function(data,
   }
   metrics <- metrics[sapply(metrics, is.function)]
 
-  # fix names if there are none provided
-  # todo
-
   # need to check the functions used here
   # i.e. check the function has the relevant arguments.
 

--- a/man/brier_score.Rd
+++ b/man/brier_score.Rd
@@ -4,7 +4,7 @@
 \alias{brier_score}
 \title{Brier Score}
 \usage{
-brier_score(true_values, predictions)
+brier_score(true_values, predictions, ...)
 }
 \arguments{
 \item{true_values}{A vector with the true observed values of size n with
@@ -12,6 +12,8 @@ all values equal to either 0 or 1}
 
 \item{predictions}{A vector with a predicted probability
 that true_value = 1.}
+
+\item{...}{additional arguments (not currently used)}
 }
 \value{
 A numeric value with the Brier Score, i.e. the mean squared

--- a/man/logs_binary.Rd
+++ b/man/logs_binary.Rd
@@ -4,7 +4,7 @@
 \alias{logs_binary}
 \title{Log Score for Binary outcomes}
 \usage{
-logs_binary(true_values, predictions)
+logs_binary(true_values, predictions, ...)
 }
 \arguments{
 \item{true_values}{A vector with the true observed values of size n with
@@ -12,6 +12,8 @@ all values equal to either 0 or 1}
 
 \item{predictions}{A vector with a predicted probability
 that true_value = 1.}
+
+\item{...}{additional arguments (not currently used)}
 }
 \value{
 A numeric value with the Log Score, i.e. the mean squared

--- a/man/score_binary.Rd
+++ b/man/score_binary.Rd
@@ -4,7 +4,7 @@
 \alias{score_binary}
 \title{Evaluate forecasts in a Binary Format}
 \usage{
-score_binary(data, forecast_unit, metrics)
+score_binary(data, forecast_unit, metrics, ...)
 }
 \arguments{
 \item{data}{A data.frame or data.table with the predictions and observations.
@@ -41,6 +41,9 @@ of the values in \code{forecast_unit}.}
 \item{metrics}{the metrics you want to have in the output. If \code{NULL} (the
 default), all available metrics will be computed. For a list of available
 metrics see \code{\link[=available_metrics]{available_metrics()}}, or  check the \link{metrics} data set.}
+
+\item{...}{additional parameters passed down to \code{\link[=score_quantile]{score_quantile()}} (internal
+function used for scoring forecasts in a quantile-based format).}
 }
 \value{
 A data.table with appropriate scores. For more information see

--- a/tests/testthat/test-score.R
+++ b/tests/testthat/test-score.R
@@ -32,8 +32,8 @@ test_that("function produces output for a binary case", {
     colnames(eval),
     c(
       "model", "target_type",
-      "brier_score",
-      "log_score"
+      "log_score",
+      "brier_score"
     )
   )
 })
@@ -181,7 +181,7 @@ test_that(
   )
   scores <- suppressWarnings(score(ex))
   expect_snapshot(summarise_scores(
-    summarise_scores(scores, by = "model"), by = "model", 
+    summarise_scores(scores, by = "model"), by = "model",
     fun = signif, digits = 2
   ))
  })

--- a/tests/testthat/test-score.R
+++ b/tests/testthat/test-score.R
@@ -185,3 +185,42 @@ test_that(
     fun = signif, digits = 2
   ))
  })
+
+
+test_that(
+  "passing additional functions to score binary works", {
+    test_fun <- function(x, y, ...) {
+      if (hasArg("test")) {
+        print("test argument found")
+        return(111)
+      }
+      return(y)
+    }
+
+    df <- example_binary[model == "EuroCOVIDhub-ensemble" & target_type == "Cases"]
+
+    # passing a simple function works
+    score(df,
+          metrics = list("identity" = function(x, y) {return(y)}))
+
+    # passing an additional argument that is not part of the function
+    # definition works
+    score(df,
+          metrics = list("identity" = function(x, y) {return(y)}),
+          additional_arg = "something")
+
+    # passing an additional function to one that accepts ... works
+    res <- score(df,
+          metrics = list("test_function" = test_fun),
+          test = "something")
+    expect_equal(unique(res$test_function), 111)
+
+    # passing an argument that's the same as a named argument
+    score(df,
+          metrics = list("test_function" = test_fun),
+          y = "something")
+
+    # this one is currently not working
+    # score(example_binary, test_fun)
+  }
+)


### PR DESCRIPTION
This PR proposes an outline for how to implement custom scoring in scoringutils. 
It starts with `score_binary()` as that is easiest in terms of input/output formats. It updates the `check_metrics()` function to accommodate passing in arbitrary functions and adds some tests. 

Currently missing: 
- a nice way to handle the conversion from our own metric names to functions (there are a few ugly lines in `score_binary()` that are glowing in the dark 
- some way to check the functions passed in. Not sure about the best way to do that.
- some more thinking about input formats, but I'll do that in another PR
- Support for the other score() subfunctions. 

I think the PR is good for a first review to make sure this is roughly what we want and then needs some further cleaning