### PR TITLE
Fix small issues resulting from the merging lots of updates into dev

### DIFF
--- a/R/correlations.R
+++ b/R/correlations.R
@@ -21,8 +21,6 @@
 correlation <- function(scores,
                         metrics = NULL,
                         digits = NULL) {
-  metrics <- check_metrics(metrics)
-
   metrics <- get_metrics(scores)
 
   # if quantile column is present, throw a warning

--- a/tests/testthat/test-plot_correlation.R
+++ b/tests/testthat/test-plot_correlation.R
@@ -1,5 +1,5 @@
 test_that("plot_correlation() works as expected", {
-  correlations <- correlation(summarise_scores(scores), digits = 2)
+  correlations <- correlation(summarise_scores(scores_quantile), digits = 2)
   p <- plot_correlation(correlations)
   expect_s3_class(p, "ggplot")
   skip_on_cran()


### PR DESCRIPTION
We recently merged a large number of PRs into the dev branch. There was, however, one previous update to `correlation()` only made to dev that led checks on dev to fail after the merge marathon.

Changes I had to make were pretty minor though:
- I had remove a function from correlation(), check_metric(), that should not exist anymore after all the updates.
- had to rename scores to scores_quantile in a failing test that got updated on dev previously, but not in all the branches we merged.