### PR TITLE
Issue #480: Fix gh action

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: '3.5'}
+          - {os: ubuntu-latest,   r: '3.6'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -73,5 +73,5 @@ URL: https://doi.org/10.48550/arXiv.2205.07090, https://epiforecasts.io/scoringu
 BugReports: https://github.com/epiforecasts/scoringutils/issues
 VignetteBuilder: knitr
 Depends: 
-    R (>= 3.5)
+    R (>= 3.6)
 Roxygen: list(markdown = TRUE)

--- a/R/correlations.R
+++ b/R/correlations.R
@@ -21,8 +21,6 @@
 correlation <- function(scores,
                         metrics = NULL,
                         digits = NULL) {
-  metrics <- check_metrics(metrics)
-
   metrics <- get_metrics(scores)
 
   # if quantile column is present, throw a warning

--- a/tests/testthat/test-plot_correlation.R
+++ b/tests/testthat/test-plot_correlation.R
@@ -1,5 +1,5 @@
 test_that("plot_correlation() works as expected", {
-  correlations <- correlation(summarise_scores(scores), digits = 2)
+  correlations <- correlation(summarise_scores(scores_quantile), digits = 2)
   p <- plot_correlation(correlations)
   expect_s3_class(p, "ggplot")
   skip_on_cran()

--- a/tests/testthat/test-plot_interval_coverage.R
+++ b/tests/testthat/test-plot_interval_coverage.R
@@ -1,5 +1,5 @@
 test_that("plot_interval_coverage() works as expected", {
-  coverage <- add_coverage(example_quantile) |>
+  coverage <- add_coverage(example_quantile) %>%
     summarise_scores(by = c("model", "range"))
   p <- plot_interval_coverage(coverage)
   expect_s3_class(p, "ggplot")

--- a/tests/testthat/test-plot_quantile_coverage.R
+++ b/tests/testthat/test-plot_quantile_coverage.R
@@ -1,5 +1,5 @@
 test_that("plot_quantile_coverage() works as expected", {
-  coverage <- add_coverage(example_quantile) |>
+  coverage <- add_coverage(example_quantile) %>%
     summarise_scores(by = c("model", "quantile"))
 
   p <- plot_quantile_coverage(coverage)

--- a/tests/testthat/test-plot_ranges.R
+++ b/tests/testthat/test-plot_ranges.R
@@ -1,8 +1,8 @@
 m <- modifyList(metrics_no_cov_no_ae, list("bias" = NULL))
 
 sum_scores <- copy(example_quantile) %>%
-  .[, interval_range := scoringutils:::get_range_from_quantile(quantile)] |>
-  score(metrics = m) |>
+  .[, interval_range := scoringutils:::get_range_from_quantile(quantile)] %>%
+  score(metrics = m) %>%
   summarise_scores(by = c("model", "target_type", "interval_range"))
 
 sum_scores[, range := interval_range]


### PR DESCRIPTION
Fixes #480 

As discussed in #480, Github action checks for R 3.5 are currently failing. This is because some packages that scoringutils imports or suggests depend on R >= 3.6. 

This PR
- makes the dependency on R 3.6 explicit in DESCRIPTION
- updates gh action to use R 3.6 instead of R 3.5
- replaces `|>` with `%>%` in some tests that failed because of the new pipe operator
