### PR TITLE
Issue #480: Update to R version 3.6 to fix failing gh action

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: '3.5'}
+          - {os: ubuntu-latest,   r: '3.6'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scoringutils
 Title: Utilities for Scoring and Assessing Predictions
-Version: 1.2.1
+Version: 1.2.2
 Language: en-GB
 Authors@R: c(
     person(given = "Nikos",
@@ -71,5 +71,5 @@ URL: https://doi.org/10.48550/arXiv.2205.07090, https://epiforecasts.io/scoringu
 BugReports: https://github.com/epiforecasts/scoringutils/issues
 VignetteBuilder: knitr
 Depends: 
-    R (>= 3.5)
+    R (>= 3.6)
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# scoringutils 1.2.2
+
+## Package updates
+- `scoringutils` now depends on R 3.6. The change was made since packages `testthat` and `lifecycle`, which are used in `scoringutils` now require R 3.6. We also updated the Github action CI check to work with R 3.6 now. 
+
 # scoringutils 1.2.1
 
 ## Package updates


### PR DESCRIPTION
This PR tracks changes made in #483 (apart from the added NEWS item), but targets them at main instead of the development branch. The version targeted at the develop branch has already been reviewed and approved. 

---

Fixes https://github.com/epiforecasts/scoringutils/issues/480

As discussed in https://github.com/epiforecasts/scoringutils/issues/480, Github action checks for R 3.5 are currently failing. This is because some packages that scoringutils imports or suggests depend on R >= 3.6.

This PR

- makes the dependency on R 3.6 explicit in DESCRIPTION
- updates gh action to use R 3.6 instead of R 3.5
- adds a news item