### PR TITLE
Issue #486: Add startup message for a new CRAN release

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,7 @@
+.onAttach <- function(libname, pkgname) {
+  packageStartupMessage(
+    "Note: scoringutils is currently undergoing major development changes ",
+    "(with an update planned for February 1st, 2024). We would very much ",
+    "appreciate your opinions and feedback on what should be included in this ",
+    "major update: https://github.com/epiforecasts/scoringutils/discussions/333")
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,5 +3,6 @@
     "Note: scoringutils is currently undergoing major development changes ",
     "(with an update planned for February 1st, 2024). We would very much ",
     "appreciate your opinions and feedback on what should be included in this ",
-    "major update: https://github.com/epiforecasts/scoringutils/discussions/333")
+    "major update: https://github.com/epiforecasts/scoringutils/discussions/333"
+  )
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,8 +1,9 @@
 .onAttach <- function(libname, pkgname) {
   packageStartupMessage(
     "Note: scoringutils is currently undergoing major development changes ",
-    "(with an update planned for February 1st, 2024). We would very much ",
-    "appreciate your opinions and feedback on what should be included in this ",
-    "major update: https://github.com/epiforecasts/scoringutils/discussions/333"
+    "(with an update planned for the first quarter of 2024). We would very ",
+    "much appreciate your opinions and feedback on what should be included in ",
+    "this major update: ",
+    "https://github.com/epiforecasts/scoringutils/discussions/333"
   )
 }


### PR DESCRIPTION
Fixes #486

**Update**: After discussing this with @sbfnk I removed the specific release date and replaced it by "first quarter of 2024" as that gives us a bit more room and freedom. See https://github.com/epiforecasts/scoringutils/issues/493 for a plan of future development steps. There is still some uncertainty about which issues should be part of which release and how best to avoid too many breaking changes on CRAN. 

This PR adds a new startup message to the package warning users of upcoming changes and announcing a planned release date (February 1 2024), as well as asking them for feedback (by linking to the discussion here: https://github.com/epiforecasts/scoringutils/discussions/333)

