### PR TITLE
Create a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
+ 
+## Description
+
+This PR closes #<issue-number>.
+
+[Describe the changes that you made in this pull request.]
+
+## Checklist
+
+- [ ] My PR is based on a package issue and I have explicitly linked it.
+- [ ] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
+- [ ] I have tested my changes locally.
+- [ ] I have added or updated unit tests where necessary.
+- [ ] I have updated the documentation if required.
+- [ ] I have built the package locally and run rebuilt docs using roxygen2.
+- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
+- [ ] I have added a news item linked to this PR.
+- [ ] I have updated the package development version by one increment in both `NEWS.md` and the `DESCRIPTION`.
+- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.
+
+<!-- Thanks again for this PR - @epinowcast dev team -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,4 @@ This PR closes #<issue-number>.
 - [ ] I have updated the package development version by one increment in both `NEWS.md` and the `DESCRIPTION`.
 - [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.
 
-<!-- Thanks again for this PR - @epinowcast dev team -->
+<!-- Thanks again for this PR - @scoringutils dev team -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,6 @@ This PR closes #<issue-number>.
 - [ ] I have built the package locally and run rebuilt docs using roxygen2.
 - [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
 - [ ] I have added a news item linked to this PR.
-- [ ] I have updated the package development version by one increment in both `NEWS.md` and the `DESCRIPTION`.
 - [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.
 
 <!-- Thanks again for this PR - @scoringutils dev team -->

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Package updates
 - `scoringutils` now depends on R 3.6. The change was made since packages `testthat` and `lifecycle`, which are used in `scoringutils` now require R 3.6. We also updated the Github action CI check to work with R 3.6 now. 
+- Added a new PR template with a checklist of things to be included in PRs to facilitate the development and review process
 
 # scoringutils 1.2.1
 


### PR DESCRIPTION
Ruthlessly stealing from [epinowcast](https://github.com/epinowcast/epinowcast) this PR adds a PR template for new PRs to follow. 
For the last time ever, with this PR, I enjoy the freedom of writing whatever I want in a pull request. Alas, I am not to be trusted and including a PR template will hopefully include the quality of future PRs by providing an explicit checklist for things to do and think about before opening a PR. 