### PR TITLE
Issue #500: Reduce messages in `bias_quantile()`

### DIFF
--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -390,8 +390,16 @@ bias_quantile <- function(observed, predicted, quantile, na.rm = TRUE) {
   if (is.null(dim(predicted))) {
     dim(predicted) <- c(n, N)
   }
+  if (!(0.5 %in% quantile)) {
+    message(
+      "Median not available, computing bias as mean of the two innermost ",
+      "quantiles in order to compute bias."
+    )
+  }
   bias <- sapply(1:n, function(i) {
-    bias_quantile_single_vector(observed[i], predicted[i,], quantile, na.rm)
+    suppressMessages(
+      bias_quantile_single_vector(observed[i], predicted[i, ], quantile, na.rm)
+    )
   })
   return(bias)
 }
@@ -438,8 +446,8 @@ bias_quantile_single_vector <- function(observed, predicted, quantile, na.rm) {
   } else {
     # if median is not available, compute as mean of two innermost quantile
     message(
-      "Median not available, computing as mean of two innermost quantile",
-      " in order to compute bias."
+      "Median not available, computing bias as mean of the two innermost ",
+      "quantiles in order to compute bias."
     )
     median_prediction <-
       0.5 * predicted[quantile == max(quantile[quantile < 0.5])] +

--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -397,9 +397,7 @@ bias_quantile <- function(observed, predicted, quantile, na.rm = TRUE) {
     )
   }
   bias <- sapply(1:n, function(i) {
-    suppressMessages(
-      bias_quantile_single_vector(observed[i], predicted[i, ], quantile, na.rm)
-    )
+    bias_quantile_single_vector(observed[i], predicted[i, ], quantile, na.rm)
   })
   return(bias)
 }
@@ -445,10 +443,6 @@ bias_quantile_single_vector <- function(observed, predicted, quantile, na.rm) {
     median_prediction <- predicted[quantile == 0.5]
   } else {
     # if median is not available, compute as mean of two innermost quantile
-    message(
-      "Median not available, computing bias as mean of the two innermost ",
-      "quantiles in order to compute bias."
-    )
     median_prediction <-
       0.5 * predicted[quantile == max(quantile[quantile < 0.5])] +
       0.5 * predicted[quantile == min(quantile[quantile > 0.5])]

--- a/tests/testthat/test-metrics-quantile.R
+++ b/tests/testthat/test-metrics-quantile.R
@@ -791,3 +791,10 @@ test_that("bias_quantile(): quantiles must be unique", {
   quantiles <- c(0.3, 0.5, 0.8, 0.9)
   expect_silent(bias_quantile(observed = 3, predicted, quantiles))
 })
+
+test_that("bias_quantile only produces one message", {
+  expect_message(
+    bias_quantile(observed, predicted[, -3], quantile[-3]),
+    "Median not available, computing bias as mean of the two innermost quantiles in order to compute bias."
+  )
+})


### PR DESCRIPTION
Fixes #500 

Currently, bias_quantile() uses an internal helper function, bias_quantile_single_vector() to compute bias for a single forecast.

This helper functions throws a message if the median is not part of the quantile levels provided. That means that a single call to bias_quantile() can produce a lot of messages, as the message is repeated every time the helper is called. 
This PR 
- moves the message from the helper function to bias_quantile(), thus only getting one message for a single call to bias_quantile().
- adds a test for this

This is related to #418 (and only addresses a small part of the larger problem), but is in my opinion definitely an improvement over what we currently have. 

