### PR TITLE
Issue 486: Fix NOTEs for CRAN submission

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@
 ^\.devcontainer$
 ^CODE_OF_CONDUCT\.md$
 ^inst/manuscript/output$
+^CRAN-SUBMISSION$

--- a/R/avail_forecasts.R
+++ b/R/avail_forecasts.R
@@ -27,7 +27,7 @@
 #' @export
 #' @keywords check-forecasts
 #' @examples
-#' data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+#' \dontshow{data.table::setDTthreads(2) # only needed to avoid issues on CRAN}
 #'
 #' avail_forecasts(example_quantile,
 #'   collapse = c("quantile"),

--- a/R/avail_forecasts.R
+++ b/R/avail_forecasts.R
@@ -27,7 +27,9 @@
 #' @export
 #' @keywords check-forecasts
 #' @examples
-#' \dontshow{data.table::setDTthreads(2) # only needed to avoid issues on CRAN}
+#' \dontshow{
+#'   data.table::setDTthreads(2) # restricts number of cores used on CRAN
+#' }
 #'
 #' avail_forecasts(example_quantile,
 #'   collapse = c("quantile"),

--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -52,7 +52,9 @@
 #' @author Johannes Bracher, \email{johannes.bracher@@kit.edu}
 #' @keywords scoring
 #' @examples
-#' data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+#' \dontshow{
+#'   data.table::setDTthreads(2) # restricts number of cores used on CRAN
+#' }
 #'
 #' scores <- score(example_quantile)
 #' pairwise <- pairwise_comparison(scores, by = "target_type")

--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -229,8 +229,8 @@ pairwise_comparison_one_group <- function(scores,
 
   # make result character instead of factor
   result[, `:=`(
-    "model" = as.character(model),
-    "compare_against" = as.character(compare_against)
+    model = as.character(model),
+    compare_against = as.character(compare_against)
   )]
 
   # calculate relative skill as geometric mean

--- a/R/pit.R
+++ b/R/pit.R
@@ -127,10 +127,10 @@ pit_sample <- function(true_values,
 
   # check data type ------------------------------------------------------------
   # check whether continuous or integer
-  if (!isTRUE(all.equal(as.vector(predictions), as.integer(predictions)))) {
-    continuous_predictions <- TRUE
-  } else {
+  if (isTRUE(all.equal(as.vector(predictions), as.integer(predictions)))) {
     continuous_predictions <- FALSE
+  } else {
+    continuous_predictions <- TRUE
   }
 
   # calculate PIT-values -------------------------------------------------------
@@ -219,7 +219,7 @@ pit <- function(data,
     value.var = "prediction"
   )
 
-  pit <- data_wide[, .("pit_value" = pit_sample(
+  pit <- data_wide[, .(pit_value = pit_sample(
     true_values = true_value,
     predictions = as.matrix(.SD)
   )),

--- a/R/pit.R
+++ b/R/pit.R
@@ -62,7 +62,9 @@
 #' @seealso [pit()]
 #' @importFrom stats runif
 #' @examples
-#' data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+#' \dontshow{
+#'   data.table::setDTthreads(2) # restricts number of cores used on CRAN
+#' }
 #'
 #' ## continuous predictions
 #' true_values <- rnorm(20, mean = 1:20)

--- a/R/plot.R
+++ b/R/plot.R
@@ -472,7 +472,7 @@ plot_predictions <- function(data,
   # it separately here to deal with the case when only the median is provided
   # (in which case ggdist::geom_lineribbon() will fail)
   if (0 %in% range) {
-    select_median <- (forecasts$range %in% 0 & forecasts$boundary == "lower")
+    select_median <- (forecasts$range == 0 & forecasts$boundary == "lower")
     median <- forecasts[select_median]
 
     if (nrow(median) > 0) {

--- a/R/plot.R
+++ b/R/plot.R
@@ -24,7 +24,9 @@
 #' @examples
 #' library(ggplot2)
 #' library(magrittr) # pipe operator
-#' data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+#' \dontshow{
+#'   data.table::setDTthreads(2) # restricts number of cores used on CRAN
+#' }
 #'
 #' scores <- score(example_quantile) %>%
 #'   summarise_scores(by = c("model", "target_type")) %>%
@@ -582,7 +584,9 @@ make_na <- make_NA
 #' @importFrom data.table dcast
 #' @export
 #' @examples
-#' data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+#' \dontshow{
+#'   data.table::setDTthreads(2) # restricts number of cores used on CRAN
+#' }
 #' scores <- score(example_quantile)
 #' scores <- summarise_scores(scores, by = c("model", "range"))
 #' plot_interval_coverage(scores)
@@ -835,7 +839,9 @@ plot_pairwise_comparison <- function(comparison_result,
 #' @importFrom stats density
 #' @return vector with the scoring values
 #' @examples
-#' data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+#' \dontshow{
+#'   data.table::setDTthreads(2) # restricts number of cores used on CRAN
+#' }
 #'
 #' # PIT histogram in vector based format
 #' true_values <- rnorm(30, mean = 1:30)

--- a/R/score.R
+++ b/R/score.R
@@ -75,7 +75,9 @@
 #'
 #' @examples
 #' library(magrittr) # pipe operator
-#' data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+#' \dontshow{
+#'   data.table::setDTthreads(2) # restricts number of cores used on CRAN
+#' }
 #'
 #' check_forecasts(example_quantile)
 #' score(example_quantile) %>%

--- a/R/summarise_scores.R
+++ b/R/summarise_scores.R
@@ -42,7 +42,9 @@
 #' provided to `fun`. For more information see the documentation of the
 #' respective function.
 #' @examples
-#' data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+#' \dontshow{
+#'   data.table::setDTthreads(2) # restricts number of cores used on CRAN
+#' }
 #' library(magrittr) # pipe operator
 #'
 #' scores <- score(example_continuous)
@@ -279,7 +281,9 @@ check_summary_params <- function(scores,
 #' summary is present according to the value specified in `by`.
 #' @examples
 #' library(magrittr) # pipe operator
-#' data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+#' \dontshow{
+#'   data.table::setDTthreads(2) # restricts number of cores used on CRAN
+#' }
 #' score(example_quantile) %>%
 #'   add_coverage(by = c("model", "target_type")) %>%
 #'   summarise_scores(by = c("model", "target_type")) %>%

--- a/R/summarise_scores.R
+++ b/R/summarise_scores.R
@@ -279,6 +279,7 @@ check_summary_params <- function(scores,
 #' summary is present according to the value specified in `by`.
 #' @examples
 #' library(magrittr) # pipe operator
+#' data.table::setDTthreads(1) # only needed to avoid issues on CRAN
 #' score(example_quantile) %>%
 #'   add_coverage(by = c("model", "target_type")) %>%
 #'   summarise_scores(by = c("model", "target_type")) %>%

--- a/man/add_coverage.Rd
+++ b/man/add_coverage.Rd
@@ -33,6 +33,7 @@ the unit of a single forecast.
 }
 \examples{
 library(magrittr) # pipe operator
+data.table::setDTthreads(1) # only needed to avoid issues on CRAN
 score(example_quantile) \%>\%
   add_coverage(by = c("model", "target_type")) \%>\%
   summarise_scores(by = c("model", "target_type")) \%>\%

--- a/man/add_coverage.Rd
+++ b/man/add_coverage.Rd
@@ -33,7 +33,9 @@ the unit of a single forecast.
 }
 \examples{
 library(magrittr) # pipe operator
-data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+\dontshow{
+  data.table::setDTthreads(2) # restricts number of cores used on CRAN
+}
 score(example_quantile) \%>\%
   add_coverage(by = c("model", "target_type")) \%>\%
   summarise_scores(by = c("model", "target_type")) \%>\%

--- a/man/avail_forecasts.Rd
+++ b/man/avail_forecasts.Rd
@@ -57,7 +57,7 @@ number of forecasts per model and location).
 This is useful to determine whether there are any missing forecasts.
 }
 \examples{
-data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+\dontshow{data.table::setDTthreads(2) # only needed to avoid issues on CRAN}
 
 avail_forecasts(example_quantile,
   collapse = c("quantile"),

--- a/man/avail_forecasts.Rd
+++ b/man/avail_forecasts.Rd
@@ -57,7 +57,9 @@ number of forecasts per model and location).
 This is useful to determine whether there are any missing forecasts.
 }
 \examples{
-\dontshow{data.table::setDTthreads(2) # only needed to avoid issues on CRAN}
+\dontshow{
+  data.table::setDTthreads(2) # restricts number of cores used on CRAN
+}
 
 avail_forecasts(example_quantile,
   collapse = c("quantile"),

--- a/man/pairwise_comparison.Rd
+++ b/man/pairwise_comparison.Rd
@@ -64,7 +64,9 @@ The implementation of the permutation test follows the function
 Andrea Riebler and Michaela Paul.
 }
 \examples{
-data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+\dontshow{
+  data.table::setDTthreads(2) # restricts number of cores used on CRAN
+}
 
 scores <- score(example_quantile)
 pairwise <- pairwise_comparison(scores, by = "target_type")

--- a/man/pit_sample.Rd
+++ b/man/pit_sample.Rd
@@ -76,7 +76,9 @@ In this context it should be noted, though, that uniformity of the
 PIT is a necessary but not sufficient condition of calibration.
 }
 \examples{
-data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+\dontshow{
+  data.table::setDTthreads(2) # restricts number of cores used on CRAN
+}
 
 ## continuous predictions
 true_values <- rnorm(20, mean = 1:20)

--- a/man/plot_interval_coverage.Rd
+++ b/man/plot_interval_coverage.Rd
@@ -21,7 +21,9 @@ ggplot object with a plot of interval coverage
 Plot interval coverage
 }
 \examples{
-data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+\dontshow{
+  data.table::setDTthreads(2) # restricts number of cores used on CRAN
+}
 scores <- score(example_quantile)
 scores <- summarise_scores(scores, by = c("model", "range"))
 plot_interval_coverage(scores)

--- a/man/plot_pit.Rd
+++ b/man/plot_pit.Rd
@@ -32,7 +32,9 @@ Make a simple histogram of the probability integral transformed values to
 visually check whether a uniform distribution seems likely.
 }
 \examples{
-data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+\dontshow{
+  data.table::setDTthreads(2) # restricts number of cores used on CRAN
+}
 
 # PIT histogram in vector based format
 true_values <- rnorm(30, mean = 1:30)

--- a/man/plot_score_table.Rd
+++ b/man/plot_score_table.Rd
@@ -31,7 +31,9 @@ Plots a coloured table of summarised scores obtained using
 \examples{
 library(ggplot2)
 library(magrittr) # pipe operator
-data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+\dontshow{
+  data.table::setDTthreads(2) # restricts number of cores used on CRAN
+}
 
 scores <- score(example_quantile) \%>\%
   summarise_scores(by = c("model", "target_type")) \%>\%

--- a/man/score.Rd
+++ b/man/score.Rd
@@ -81,7 +81,9 @@ as well as the paper \href{https://arxiv.org/abs/2205.07090}{Evaluating Forecast
 }
 \examples{
 library(magrittr) # pipe operator
-data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+\dontshow{
+  data.table::setDTthreads(2) # restricts number of cores used on CRAN
+}
 
 check_forecasts(example_quantile)
 score(example_quantile) \%>\%

--- a/man/summarise_scores.Rd
+++ b/man/summarise_scores.Rd
@@ -81,7 +81,9 @@ respective function.}
 Summarise scores as produced by \code{\link[=score]{score()}}
 }
 \examples{
-data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+\dontshow{
+  data.table::setDTthreads(2) # restricts number of cores used on CRAN
+}
 library(magrittr) # pipe operator
 
 scores <- score(example_continuous)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,6 +1,7 @@
 # load common required test packages
 library(ggplot2, quietly = TRUE)
 suppressMessages(library(magrittr))
+data.table::setDTthreads(1) # only needed to avoid issues on CRAN
 
 # compute quantile scores
 scores <- suppressMessages(score(example_quantile))

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,7 +1,7 @@
 # load common required test packages
 library(ggplot2, quietly = TRUE)
 suppressMessages(library(magrittr))
-data.table::setDTthreads(2) # only needed to avoid issues on CRAN
+data.table::setDTthreads(2) # restricts number of cores used on CRAN
 
 # compute quantile scores
 scores <- suppressMessages(score(example_quantile))

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,7 +1,7 @@
 # load common required test packages
 library(ggplot2, quietly = TRUE)
 suppressMessages(library(magrittr))
-data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+data.table::setDTthreads(2) # only needed to avoid issues on CRAN
 
 # compute quantile scores
 scores <- suppressMessages(score(example_quantile))

--- a/vignettes/scoringutils.Rmd
+++ b/vignettes/scoringutils.Rmd
@@ -19,8 +19,8 @@ library(magrittr)
 library(data.table)
 library(ggplot2)
 library(knitr)
-# number of threads used for data.table computation, update as needed
-data.table::setDTthreads(2) 
+# number of threads used for data.table computations, update as needed
+data.table::setDTthreads(2)
 ```
 
 The `scoringutils` package provides a collection of metrics and proper scoring rules that make it simple to score probabilistic forecasts against the true observed values. You can find more information in the paper [Evaluating Forecasts with scoringutils in R](https://arxiv.org/abs/2205.07090) as well as the [Metrics-Vignette](https://epiforecasts.io/scoringutils/articles/metric-details.html) and the [Scoring forecasts directly Vignette](https://epiforecasts.io/scoringutils/articles/scoring-forecasts-directly.html).

--- a/vignettes/scoringutils.Rmd
+++ b/vignettes/scoringutils.Rmd
@@ -19,7 +19,7 @@ library(magrittr)
 library(data.table)
 library(ggplot2)
 library(knitr)
-data.table::setDTthreads(2) # only needed to avoid issues on CRAN
+data.table::setDTthreads(2) # restricts number of cores used on CRAN
 ```
 
 The `scoringutils` package provides a collection of metrics and proper scoring rules that make it simple to score probabilistic forecasts against the true observed values. You can find more information in the paper [Evaluating Forecasts with scoringutils in R](https://arxiv.org/abs/2205.07090) as well as the [Metrics-Vignette](https://epiforecasts.io/scoringutils/articles/metric-details.html) and the [Scoring forecasts directly Vignette](https://epiforecasts.io/scoringutils/articles/scoring-forecasts-directly.html).

--- a/vignettes/scoringutils.Rmd
+++ b/vignettes/scoringutils.Rmd
@@ -19,6 +19,7 @@ library(magrittr)
 library(data.table)
 library(ggplot2)
 library(knitr)
+data.table::setDTthreads(1) # only needed to avoid issues on CRAN
 ```
 
 The `scoringutils` package provides a collection of metrics and proper scoring rules that make it simple to score probabilistic forecasts against the true observed values. You can find more information in the paper [Evaluating Forecasts with scoringutils in R](https://arxiv.org/abs/2205.07090) as well as the [Metrics-Vignette](https://epiforecasts.io/scoringutils/articles/metric-details.html) and the [Scoring forecasts directly Vignette](https://epiforecasts.io/scoringutils/articles/scoring-forecasts-directly.html).

--- a/vignettes/scoringutils.Rmd
+++ b/vignettes/scoringutils.Rmd
@@ -19,7 +19,8 @@ library(magrittr)
 library(data.table)
 library(ggplot2)
 library(knitr)
-data.table::setDTthreads(2) # restricts number of cores used on CRAN
+# number of threads used for data.table computation, update as needed
+data.table::setDTthreads(2) 
 ```
 
 The `scoringutils` package provides a collection of metrics and proper scoring rules that make it simple to score probabilistic forecasts against the true observed values. You can find more information in the paper [Evaluating Forecasts with scoringutils in R](https://arxiv.org/abs/2205.07090) as well as the [Metrics-Vignette](https://epiforecasts.io/scoringutils/articles/metric-details.html) and the [Scoring forecasts directly Vignette](https://epiforecasts.io/scoringutils/articles/scoring-forecasts-directly.html).

--- a/vignettes/scoringutils.Rmd
+++ b/vignettes/scoringutils.Rmd
@@ -19,7 +19,7 @@ library(magrittr)
 library(data.table)
 library(ggplot2)
 library(knitr)
-data.table::setDTthreads(1) # only needed to avoid issues on CRAN
+data.table::setDTthreads(2) # only needed to avoid issues on CRAN
 ```
 
 The `scoringutils` package provides a collection of metrics and proper scoring rules that make it simple to score probabilistic forecasts against the true observed values. You can find more information in the paper [Evaluating Forecasts with scoringutils in R](https://arxiv.org/abs/2205.07090) as well as the [Metrics-Vignette](https://epiforecasts.io/scoringutils/articles/metric-details.html) and the [Scoring forecasts directly Vignette](https://epiforecasts.io/scoringutils/articles/scoring-forecasts-directly.html).
@@ -36,7 +36,7 @@ Most of the time, the `score()` function will be able to do the entire evaluatio
 
 ```{r, echo=FALSE}
 requirements <- data.table(
-  "Format" = c(
+  Format = c(
     "quantile-based", "sample-based", "binary", "pairwise-comparisons"
   ),
   `Required columns` = c(


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #486

During CRAN submission, we got a Note on one of CRAN's machines that CPU time > elapsed time for some examples, tests, and the vignette- this is usually the case when more than 2 cores are used. We had that issue in the past and is almost certainly linked to `data.table` (see https://github.com/Rdatatable/data.table/issues/3300 and https://github.com/Rdatatable/data.table/issues/5658). 

To "solve" this I added the line `data.table::setDTthreads(2)` before offending code. This is what was suggested in https://github.com/Rdatatable/data.table/issues/5658 by the `data.table` maintainers. 

(The PR also makes a single unrelated linting fix in the vignette)

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] ~~I have added or updated unit tests where necessary.~~
- [x] ~~I have updated the documentation if required.~~
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] ~~I have added a news item linked to this PR.~~
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
