### PR TITLE
Issue #275: Fix handling of scalar inputs in `logs_binary()`

### DIFF
--- a/R/metrics-binary.R
+++ b/R/metrics-binary.R
@@ -83,6 +83,6 @@ brier_score <- function(observed, predicted) {
 logs_binary <- function(observed, predicted) {
   assert_input_binary(observed, predicted)
   observed <- as.numeric(observed) - 1
-  logs <- -log(ifelse(observed == 1, predicted, 1 - predicted))
+  logs <- -log(1 - abs(observed - predicted))
   return(logs)
 }

--- a/tests/testthat/test-metrics-binary.R
+++ b/tests/testthat/test-metrics-binary.R
@@ -164,3 +164,24 @@ test_that("Binary metrics work within and outside of `score()`", {
     result$log_score
   )
 })
+
+test_that("`logs_binary()` works as expected", {
+  # check against the function Metrics::ll
+  obs2 <- as.numeric(as.character(observed))
+  expect_equal(
+    logs_binary(observed, predicted),
+    Metrics::ll(obs2, predicted)
+  )
+
+  # check this works for a single observed value
+  expect_equal(
+    logs_binary(observed[1], predicted),
+    Metrics::ll(obs2[1], predicted)
+  )
+
+  # check this works for a single predicted value
+  expect_equal(
+    logs_binary(observed, predicted[1]),
+    Metrics::ll(obs2, predicted[1])
+  )
+})


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #275.

Ideally we would like `logs_binary()` to be able to accept a single value as an input that then gets recycled just like any other vector in R does. The current implementation had an `ifelse()` statement there which did work for several observed values and a single predicted value, but not the other way round. 

This PR updates the code in `logs_binary()` to work with scalar values and adds tests against the function `ll()` from the `Metrics` package to verify everything is correct. 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] ~~I have updated the documentation if required.~~
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] ~~I have added a news item linked to this PR.~~
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
