### PR TITLE
Issue #436 Rename instances of "coverage" to either "interval coverage" or "quantile coverage"

### DIFF
--- a/R/add_coverage.R
+++ b/R/add_coverage.R
@@ -7,7 +7,7 @@
 #'
 #' **Interval coverage**
 #'
-#' Coverage for a given interval range is defined as the proportion of
+#' Interval coverage for a given interval range is defined as the proportion of
 #' observations that fall within the corresponding central prediction intervals.
 #' Central prediction intervals are symmetric around the median and and formed
 #' by two quantiles that denote the lower and upper bound. For example, the 50%
@@ -15,10 +15,11 @@
 #' quantiles of the predictive distribution.
 #'
 #' The function `add_coverage()` computes the coverage per central prediction
-#' interval, so the coverage will always be either `TRUE` (observed value falls
-#' within the interval) or `FALSE` (observed value falls outside the interval).
-#' You can summarise the coverage values to get the proportion of observations
-#' that fall within the central prediction intervals.
+#' interval, so the interval coverage will always be either `TRUE`
+#' (observed value falls within the interval) or `FALSE`  (observed value falls
+#' outside the interval). You can summarise the interval coverage values to get
+#' the proportion of observations that fall within the central prediction
+#' intervals.
 #'
 #' **Quantile coverage**
 #'
@@ -26,10 +27,13 @@
 #' observed values that are smaller than the corresponding predictive quantile.
 #' For example, the 0.5 quantile coverage is the proportion of observed values
 #' that are smaller than the 0.5 quantile of the predictive distribution.
+#' Just as above, for a single observation and the quantile of a single
+#' predictive distribution, the value will either be `TRUE` or `FALSE`.
 #'
 #' **Coverage deviation**
 #'
-#' The coverage deviation is the difference between the desired coverage and the
+#' The coverage deviation is the difference between the desired coverage
+#' (can be either interval or quantile coverage) and the
 #' actual coverage. For example, if the desired coverage is 90% and the actual
 #' coverage is 80%, the coverage deviation is -0.1.
 #'

--- a/R/default-scoring-rules.R
+++ b/R/default-scoring-rules.R
@@ -130,11 +130,11 @@ rules_sample <- function(select = NULL, exclude = NULL) {
 #' - "underprediction" = [underprediction()]
 #' - "dispersion" = [dispersion()]
 #' - "bias" = [bias_quantile()]
-#' - "coverage_50" = [interval_coverage_quantile()]
-#' - "coverage_90" = function(...) \{
+#' - "interval_coverage_50" = [interval_coverage_quantile()]
+#' - "interval_coverage_90" = function(...) \{
 #'      run_safely(..., range = 90, fun = [interval_coverage_quantile])
 #'   \}
-#' - "coverage_deviation" = [interval_coverage_dev_quantile()],
+#' - "interval_coverage_deviation" = [interval_coverage_dev_quantile()],
 #' - "ae_median" = [ae_median_quantile()]
 #'
 #' Note: The `coverage_90` scoring rule is created as a wrapper around
@@ -157,11 +157,11 @@ rules_quantile <- function(select = NULL, exclude = NULL) {
     underprediction = underprediction,
     dispersion = dispersion,
     bias = bias_quantile,
-    coverage_50 = interval_coverage_quantile,
-    coverage_90 = function(...) {
+    interval_coverage_50 = interval_coverage_quantile,
+    interval_coverage_90 = function(...) {
       run_safely(..., range = 90, fun = interval_coverage_quantile)
     },
-    coverage_deviation = interval_coverage_dev_quantile,
+    interval_coverage_deviation = interval_coverage_dev_quantile,
     ae_median = ae_median_quantile
   )
   selected <- select_rules(all, select, exclude)

--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -300,14 +300,14 @@ interval_coverage_quantile <- function(observed, predicted, quantile, range = 50
 #' @export
 #' @keywords metric
 #' @examples
-# observed <- c(1, -15, 22)
-# predicted <- rbind(
-#   c(-1, 0, 1, 2, 3),
-#   c(-2, 1, 2, 2, 4),
-#    c(-2, 0, 3, 3, 4)
-# )
-# quantile <- c(0.1, 0.25, 0.5, 0.75, 0.9)
-# interval_coverage_dev_quantile(observed, predicted, quantile)
+#' observed <- c(1, -15, 22)
+#' predicted <- rbind(
+#'   c(-1, 0, 1, 2, 3),
+#'   c(-2, 1, 2, 2, 4),
+#'   c(-2, 0, 3, 3, 4)
+#' )
+#' quantile <- c(0.1, 0.25, 0.5, 0.75, 0.9)
+#' interval_coverage_dev_quantile(observed, predicted, quantile)
 interval_coverage_dev_quantile <- function(observed, predicted, quantile) {
   assert_input_quantile(observed, predicted, quantile)
 
@@ -330,9 +330,10 @@ interval_coverage_dev_quantile <- function(observed, predicted, quantile) {
 
   reformatted <- quantile_to_interval(observed, predicted, quantile)[range != 0]
   reformatted[, interval_coverage := (observed >= lower) & (observed <= upper)]
-  reformatted[, interval_coverage_dev := interval_coverage - range / 100]
-  out <- reformatted[, .(interval_coverage_dev = mean(interval_coverage_dev)),
-                     by = "forecast_id"]
+  reformatted[, interval_coverage_deviation := interval_coverage - range / 100]
+  out <- reformatted[, .(
+    interval_coverage_deviation = mean(interval_coverage_deviation)
+  ), by = "forecast_id"]
   return(out$interval_coverage_dev)
 }
 

--- a/R/metrics-sample.R
+++ b/R/metrics-sample.R
@@ -275,7 +275,6 @@ crps_sample <- function(observed, predicted, ...) {
 #' predicted <- replicate(200, rpois(n = 30, lambda = 1:30))
 #' mad_sample(predicted = predicted)
 #' @keywords metric
-
 mad_sample <- function(observed = NULL, predicted, ...) {
 
   assert_input_sample(rep(NA_real_, nrow(predicted)), predicted)
@@ -286,13 +285,15 @@ mad_sample <- function(observed = NULL, predicted, ...) {
 
 
 #' @title Interval Coverage
-#' @description To compute coverage for sample-based forecasts,
+#' @description To compute interval coverage for sample-based forecasts,
 #' predictive samples are converted first into predictive quantiles using the
 #' sample quantiles.
 #' @importFrom checkmate assert_number
 #' @rdname interval_coverage
 #' @export
 #' @examples
+#' observed <- rpois(30, lambda = 1:30)
+#' predicted <- replicate(200, rpois(n = 30, lambda = 1:30))
 #' interval_coverage_sample(observed, predicted)
 interval_coverage_sample <- function(observed, predicted, range = 50) {
   assert_input_sample(observed, predicted)
@@ -313,7 +314,7 @@ interval_coverage_sample <- function(observed, predicted, range = 50) {
   # this could call interval_coverage_quantile instead
   # ==========================================================
   interval_dt <- quantile_to_interval(quantile_dt, format = "wide")
-  interval_dt[, coverage := (observed >= lower) & (observed <= upper)]
+  interval_dt[, interval_coverage := (observed >= lower) & (observed <= upper)]
   # ==========================================================
-  return(interval_dt$coverage)
+  return(interval_dt$interval_coverage)
 }

--- a/R/pit.R
+++ b/R/pit.R
@@ -192,7 +192,7 @@ pit <- function(data,
   if (forecast_type == "quantile") {
     data[, quantile_coverage := (observed <= predicted)]
     quantile_coverage <- data[, .(quantile_coverage = mean(quantile_coverage)),
-                     by = c(unique(c(by, "quantile")))]
+                              by = c(unique(c(by, "quantile")))]
     quantile_coverage <- quantile_coverage[order(quantile),
       .(
         quantile = c(quantile, 1),

--- a/R/pit.R
+++ b/R/pit.R
@@ -191,16 +191,16 @@ pit <- function(data,
 
   if (forecast_type == "quantile") {
     data[, quantile_coverage := (observed <= predicted)]
-    coverage <- data[, .(quantile_coverage = mean(quantile_coverage)),
+    quantile_coverage <- data[, .(quantile_coverage = mean(quantile_coverage)),
                      by = c(unique(c(by, "quantile")))]
-    coverage <- coverage[order(quantile),
+    quantile_coverage <- quantile_coverage[order(quantile),
       .(
         quantile = c(quantile, 1),
         pit_value = diff(c(0, quantile_coverage, 1))
       ),
-      by = c(get_forecast_unit(coverage))
+      by = c(get_forecast_unit(quantile_coverage))
     ]
-    return(coverage[])
+    return(quantile_coverage[])
   }
 
   # if prediction type is not quantile, calculate PIT values based on samples

--- a/R/plot.R
+++ b/R/plot.R
@@ -57,7 +57,7 @@ plot_score_table <- function(scores,
 
   # define which metrics are scaled using min (larger is worse) and
   # which not (metrics like bias where deviations in both directions are bad)
-  metrics_zero_good <- c("bias", "coverage_deviation")
+  metrics_zero_good <- c("bias", "interval_coverage_deviation")
   metrics_no_color <- "coverage"
 
   metrics_min_good <- setdiff(metrics, c(

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,7 +5,8 @@
 #' @keywords info
 available_metrics <- function() {
   return(unique(c(scoringutils::metrics$Name,
-                  "wis", "coverage_50", "coverage_90")))
+                  "wis", "interval_coverage_50", "interval_coverage_90",
+                  "interval_coverage_deviation")))
 }
 
 

--- a/man/add_coverage.Rd
+++ b/man/add_coverage.Rd
@@ -22,7 +22,7 @@ quantile format (following the input requirements of \code{score()}).
 
 \strong{Interval coverage}
 
-Coverage for a given interval range is defined as the proportion of
+Interval coverage for a given interval range is defined as the proportion of
 observations that fall within the corresponding central prediction intervals.
 Central prediction intervals are symmetric around the median and and formed
 by two quantiles that denote the lower and upper bound. For example, the 50\%
@@ -30,10 +30,11 @@ central prediction interval is the interval between the 0.25 and 0.75
 quantiles of the predictive distribution.
 
 The function \code{add_coverage()} computes the coverage per central prediction
-interval, so the coverage will always be either \code{TRUE} (observed value falls
-within the interval) or \code{FALSE} (observed value falls outside the interval).
-You can summarise the coverage values to get the proportion of observations
-that fall within the central prediction intervals.
+interval, so the interval coverage will always be either \code{TRUE}
+(observed value falls within the interval) or \code{FALSE}  (observed value falls
+outside the interval). You can summarise the interval coverage values to get
+the proportion of observations that fall within the central prediction
+intervals.
 
 \strong{Quantile coverage}
 
@@ -41,10 +42,13 @@ Quantile coverage for a given quantile is defined as the proportion of
 observed values that are smaller than the corresponding predictive quantile.
 For example, the 0.5 quantile coverage is the proportion of observed values
 that are smaller than the 0.5 quantile of the predictive distribution.
+Just as above, for a single observation and the quantile of a single
+predictive distribution, the value will either be \code{TRUE} or \code{FALSE}.
 
 \strong{Coverage deviation}
 
-The coverage deviation is the difference between the desired coverage and the
+The coverage deviation is the difference between the desired coverage
+(can be either interval or quantile coverage) and the
 actual coverage. For example, if the desired coverage is 90\% and the actual
 coverage is 80\%, the coverage deviation is -0.1.
 }

--- a/man/interval_coverage.Rd
+++ b/man/interval_coverage.Rd
@@ -24,11 +24,12 @@ vector of size N.}
 
 \item{range}{A single number with the range of the prediction interval in
 percent (e.g. 50 for a 50\% prediction interval) for which you want to compute
-coverage.}
+interval coverage.}
 }
 \value{
-A vector of length n with TRUE if the observed value is within the
-corresponding prediction interval and FALSE otherwise.
+A vector of length n with elements either TRUE,
+if the observed value is within the corresponding prediction interval, and
+FALSE otherwise.
 }
 \description{
 Check whether the observed value is within a given central
@@ -37,7 +38,7 @@ upper bound formed by a pair of predictive quantiles. For example, a 50\%
 prediction interval is formed by the 0.25 and 0.75 quantiles of the
 predictive distribution.
 
-To compute coverage for sample-based forecasts,
+To compute interval coverage for sample-based forecasts,
 predictive samples are converted first into predictive quantiles using the
 sample quantiles.
 }
@@ -50,6 +51,8 @@ predicted <- rbind(
 )
 quantile <- c(0.1, 0.25, 0.5, 0.75, 0.9)
 interval_coverage_quantile(observed, predicted, quantile)
+observed <- rpois(30, lambda = 1:30)
+predicted <- replicate(200, rpois(n = 30, lambda = 1:30))
 interval_coverage_sample(observed, predicted)
 }
 \keyword{metric}

--- a/man/interval_coverage_dev_quantile.Rd
+++ b/man/interval_coverage_dev_quantile.Rd
@@ -64,4 +64,14 @@ interval coverage deviation =
 The interval coverage deviation is then averaged across all prediction
 intervals. The median is ignored when computing coverage deviation.
 }
+\examples{
+observed <- c(1, -15, 22)
+predicted <- rbind(
+  c(-1, 0, 1, 2, 3),
+  c(-2, 1, 2, 2, 4),
+  c(-2, 0, 3, 3, 4)
+)
+quantile <- c(0.1, 0.25, 0.5, 0.75, 0.9)
+interval_coverage_dev_quantile(observed, predicted, quantile)
+}
 \keyword{metric}

--- a/man/interval_coverage_dev_quantile.Rd
+++ b/man/interval_coverage_dev_quantile.Rd
@@ -19,17 +19,17 @@ vector of size N.}
 \item{quantile}{vector with quantile levels of size N}
 }
 \value{
-A numeric vector of length n with the coverage deviation for each
-forecast (comprising one or multiple prediction intervals).
+A numeric vector of length n with the interval coverage deviation
+for each forecast (comprising one or multiple prediction intervals).
 }
 \description{
 Check the agreement between desired and actual interval coverage
 of a forecast.
 
 The function is similar to \code{\link[=interval_coverage_quantile]{interval_coverage_quantile()}},
-but looks at all provided prediction intervals instead of only one. It
-compares nominal coverage (i.e. the desired coverage) with the actual
-observed coverage.
+but takes all provided prediction intervals into account and
+compares nominal interval coverage (i.e. the desired interval coverage) with
+the actual observed interval coverage.
 
 A central symmetric prediction interval is defined by a lower and an
 upper bound formed by a pair of predictive quantiles. For example, a 50\%
@@ -39,38 +39,29 @@ predictive distribution. Ideally, a forecaster should aim to cover about
 observed values with their 90\% prediction intervals, and so on.
 
 For every prediction interval, the deviation is computed as the difference
-between the observed coverage and the nominal coverage
-For a single observed value and a single prediction interval,
-coverage is always either 0 or 1. This is not the case for a single observed
-value and multiple prediction intervals, but it still doesn't make that much
+between the observed interval coverage and the nominal interval coverage
+For a single observed value and a single prediction interval, coverage is
+always either 0 or 1 (\code{FALSE} or \code{TRUE}). This is not the case for a single
+observed value and multiple prediction intervals,
+but it still doesn't make that much
 sense to compare nominal (desired) coverage and actual coverage for a single
 observation. In that sense coverage deviation only really starts to make
 sense as a metric when averaged across multiple observations).
 
-Positive values of coverage deviation are an indication for underconfidence,
-i.e. the forecaster could likely have issued a narrower forecast. Negative
-values are an indication for overconfidence, i.e. the forecasts were too
-narrow.
+Positive values of interval coverage deviation are an indication for
+underconfidence, i.e. the forecaster could likely have issued a narrower
+forecast. Negative values are an indication for overconfidence, i.e. the
+forecasts were too narrow.
 
 \deqn{
-\textrm{coverage deviation} =
-\mathbf{1}(\textrm{observed value falls within interval} -
-\textrm{nominal coverage})
+\textrm{interval coverage deviation} =
+\mathbf{1}(\textrm{observed value falls within interval}) -
+\textrm{nominal interval coverage}
 }{
-coverage deviation =
-1(observed value falls within interval) - nominal coverage
+interval coverage deviation =
+1(observed value falls within interval) - nominal interval coverage
 }
-The coverage deviation is then averaged across all prediction intervals.
-The median is ignored when computing coverage deviation.
-}
-\examples{
-observed <- c(1, -15, 22)
-predicted <- rbind(
-  c(-1, 0, 1, 2, 3),
-  c(-2, 1, 2, 2, 4),
-   c(-2, 0, 3, 3, 4)
-)
-quantile <- c(0.1, 0.25, 0.5, 0.75, 0.9)
-interval_coverage_dev_quantile(observed, predicted, quantile)
+The interval coverage deviation is then averaged across all prediction
+intervals. The median is ignored when computing coverage deviation.
 }
 \keyword{metric}

--- a/man/rules_quantile.Rd
+++ b/man/rules_quantile.Rd
@@ -27,11 +27,11 @@ The default scoring rules are:
 \item "underprediction" = \code{\link[=underprediction]{underprediction()}}
 \item "dispersion" = \code{\link[=dispersion]{dispersion()}}
 \item "bias" = \code{\link[=bias_quantile]{bias_quantile()}}
-\item "coverage_50" = \code{\link[=interval_coverage_quantile]{interval_coverage_quantile()}}
-\item "coverage_90" = function(...) \{
+\item "interval_coverage_50" = \code{\link[=interval_coverage_quantile]{interval_coverage_quantile()}}
+\item "interval_coverage_90" = function(...) \{
 run_safely(..., range = 90, fun = \link{interval_coverage_quantile})
 \}
-\item "coverage_deviation" = \code{\link[=interval_coverage_dev_quantile]{interval_coverage_dev_quantile()}},
+\item "interval_coverage_deviation" = \code{\link[=interval_coverage_dev_quantile]{interval_coverage_dev_quantile()}},
 \item "ae_median" = \code{\link[=ae_median_quantile]{ae_median_quantile()}}
 }
 

--- a/tests/testthat/_snaps/plot_correlation/plot-correlation.svg
+++ b/tests/testthat/_snaps/plot_correlation/plot-correlation.svg
@@ -20,152 +20,152 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpOTkuMzR8NzE0LjUyfDIyLjc4fDQyNC4xMA=='>
-    <rect x='99.34' y='22.78' width='615.18' height='401.32' />
+  <clipPath id='cpMTMyLjYwfDcxNC41MnwyMi43OHwzOTAuODQ='>
+    <rect x='132.60' y='22.78' width='581.92' height='368.05' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpOTkuMzR8NzE0LjUyfDIyLjc4fDQyNC4xMA==)'>
-<rect x='648.00' y='380.70' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
-<rect x='579.41' y='380.70' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FC887A;' />
-<rect x='579.41' y='335.96' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
-<rect x='510.83' y='380.70' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFDCD6;' />
-<rect x='510.83' y='335.96' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FAFBFD;' />
-<rect x='510.83' y='291.22' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
-<rect x='442.25' y='380.70' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC5BC;' />
-<rect x='442.25' y='335.96' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD7D0;' />
-<rect x='442.25' y='291.22' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE9;' />
-<rect x='442.25' y='246.48' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
-<rect x='373.67' y='380.70' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFF1EF;' />
-<rect x='373.67' y='335.96' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFE3DE;' />
-<rect x='373.67' y='291.22' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C2D1E5;' />
-<rect x='373.67' y='246.48' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFF1EF;' />
-<rect x='373.67' y='201.74' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
-<rect x='305.08' y='380.70' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #DAE3EF;' />
-<rect x='305.08' y='335.96' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E5EBF4;' />
-<rect x='305.08' y='291.22' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #DAE3EF;' />
-<rect x='305.08' y='246.48' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #EFF3F8;' />
-<rect x='305.08' y='201.74' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFEFE;' />
-<rect x='305.08' y='157.00' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
-<rect x='236.50' y='380.70' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B7CAE0;' />
-<rect x='236.50' y='335.96' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C7D5E7;' />
-<rect x='236.50' y='291.22' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C0D0E4;' />
-<rect x='236.50' y='246.48' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #EFF3F8;' />
-<rect x='236.50' y='201.74' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFF2F0;' />
-<rect x='236.50' y='157.00' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD1C9;' />
-<rect x='236.50' y='112.26' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
-<rect x='167.92' y='380.70' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C3D3E5;' />
-<rect x='167.92' y='335.96' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D3DEEC;' />
-<rect x='167.92' y='291.22' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C5D4E6;' />
-<rect x='167.92' y='246.48' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #EAEFF6;' />
-<rect x='167.92' y='201.74' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFF7F6;' />
-<rect x='167.92' y='157.00' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FE9486;' />
-<rect x='167.92' y='112.26' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFAFA3;' />
-<rect x='167.92' y='67.52' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
-<rect x='99.34' y='380.70' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8173;' />
-<rect x='99.34' y='335.96' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FD8D7F;' />
-<rect x='99.34' y='291.22' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD4CD;' />
-<rect x='99.34' y='246.48' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFBBB1;' />
-<rect x='99.34' y='201.74' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFF2F0;' />
-<rect x='99.34' y='157.00' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D3DEEC;' />
-<rect x='99.34' y='112.26' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B7CAE0;' />
-<rect x='99.34' y='67.52' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #BCCEE2;' />
-<rect x='99.34' y='22.78' width='66.52' height='43.40' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
-<text x='681.26' y='406.20' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='612.68' y='406.20' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.94</text>
-<text x='612.68' y='361.46' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='544.09' y='406.20' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.28</text>
-<text x='544.09' y='361.46' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.03</text>
-<text x='544.09' y='316.72' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='475.51' y='406.20' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.46</text>
-<text x='475.51' y='361.46' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.32</text>
-<text x='475.51' y='316.72' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.15</text>
-<text x='475.51' y='271.98' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='406.93' y='406.20' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.11</text>
-<text x='406.93' y='361.46' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.22</text>
-<text x='406.93' y='316.72' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.35</text>
-<text x='406.93' y='271.98' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.11</text>
-<text x='406.93' y='227.24' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='338.35' y='406.20' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.21</text>
-<text x='338.35' y='361.46' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.15</text>
-<text x='338.35' y='316.72' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.21</text>
-<text x='338.35' y='271.98' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.09</text>
-<text x='338.35' y='227.24' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.01</text>
-<text x='338.35' y='182.50' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='269.76' y='406.20' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.41</text>
-<text x='269.76' y='361.46' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.32</text>
-<text x='269.76' y='316.72' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.36</text>
-<text x='269.76' y='271.98' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.09</text>
-<text x='269.76' y='227.24' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
-<text x='269.76' y='182.50' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.37</text>
-<text x='269.76' y='137.76' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='201.18' y='406.20' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.34</text>
-<text x='201.18' y='361.46' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
-<text x='201.18' y='316.72' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.33</text>
-<text x='201.18' y='271.98' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.12</text>
-<text x='201.18' y='227.24' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.06</text>
-<text x='201.18' y='182.50' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.85</text>
-<text x='201.18' y='137.76' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.64</text>
-<text x='201.18' y='93.02' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='132.60' y='406.20' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.99</text>
-<text x='132.60' y='361.46' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.9</text>
-<text x='132.60' y='316.72' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.34</text>
-<text x='132.60' y='271.98' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.54</text>
-<text x='132.60' y='227.24' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
-<text x='132.60' y='182.50' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
-<text x='132.60' y='137.76' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.41</text>
-<text x='132.60' y='93.02' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.38</text>
-<text x='132.60' y='48.28' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
+<g clip-path='url(#cpMTMyLjYwfDcxNC41MnwyMi43OHwzOTAuODQ=)'>
+<rect x='651.59' y='351.04' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
+<rect x='586.72' y='351.04' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FC887A;' />
+<rect x='586.72' y='310.01' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
+<rect x='521.84' y='351.04' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFDCD6;' />
+<rect x='521.84' y='310.01' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FAFBFD;' />
+<rect x='521.84' y='268.97' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
+<rect x='456.97' y='351.04' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC5BC;' />
+<rect x='456.97' y='310.01' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD7D0;' />
+<rect x='456.97' y='268.97' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE9;' />
+<rect x='456.97' y='227.94' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
+<rect x='392.10' y='351.04' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFF1EF;' />
+<rect x='392.10' y='310.01' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFE3DE;' />
+<rect x='392.10' y='268.97' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C2D1E5;' />
+<rect x='392.10' y='227.94' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFF1EF;' />
+<rect x='392.10' y='186.91' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
+<rect x='327.22' y='351.04' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #DAE3EF;' />
+<rect x='327.22' y='310.01' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E5EBF4;' />
+<rect x='327.22' y='268.97' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #DAE3EF;' />
+<rect x='327.22' y='227.94' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #EFF3F8;' />
+<rect x='327.22' y='186.91' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFEFE;' />
+<rect x='327.22' y='145.88' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
+<rect x='262.35' y='351.04' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B7CAE0;' />
+<rect x='262.35' y='310.01' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C7D5E7;' />
+<rect x='262.35' y='268.97' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C0D0E4;' />
+<rect x='262.35' y='227.94' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #EFF3F8;' />
+<rect x='262.35' y='186.91' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFF2F0;' />
+<rect x='262.35' y='145.88' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD1C9;' />
+<rect x='262.35' y='104.85' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
+<rect x='197.48' y='351.04' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C3D3E5;' />
+<rect x='197.48' y='310.01' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D3DEEC;' />
+<rect x='197.48' y='268.97' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C5D4E6;' />
+<rect x='197.48' y='227.94' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #EAEFF6;' />
+<rect x='197.48' y='186.91' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFF7F6;' />
+<rect x='197.48' y='145.88' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FE9486;' />
+<rect x='197.48' y='104.85' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFAFA3;' />
+<rect x='197.48' y='63.82' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
+<rect x='132.60' y='351.04' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8173;' />
+<rect x='132.60' y='310.01' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FD8D7F;' />
+<rect x='132.60' y='268.97' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD4CD;' />
+<rect x='132.60' y='227.94' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFBBB1;' />
+<rect x='132.60' y='186.91' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFF2F0;' />
+<rect x='132.60' y='145.88' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D3DEEC;' />
+<rect x='132.60' y='104.85' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B7CAE0;' />
+<rect x='132.60' y='63.82' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #BCCEE2;' />
+<rect x='132.60' y='22.78' width='62.93' height='39.80' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
+<text x='683.06' y='374.74' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='618.18' y='374.74' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.94</text>
+<text x='618.18' y='333.70' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='553.31' y='374.74' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.28</text>
+<text x='553.31' y='333.70' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.03</text>
+<text x='553.31' y='292.67' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='488.43' y='374.74' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.46</text>
+<text x='488.43' y='333.70' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.32</text>
+<text x='488.43' y='292.67' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.15</text>
+<text x='488.43' y='251.64' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='423.56' y='374.74' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.11</text>
+<text x='423.56' y='333.70' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.22</text>
+<text x='423.56' y='292.67' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.35</text>
+<text x='423.56' y='251.64' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.11</text>
+<text x='423.56' y='210.61' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='358.69' y='374.74' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.21</text>
+<text x='358.69' y='333.70' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.15</text>
+<text x='358.69' y='292.67' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.21</text>
+<text x='358.69' y='251.64' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.09</text>
+<text x='358.69' y='210.61' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.01</text>
+<text x='358.69' y='169.58' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='293.81' y='374.74' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.41</text>
+<text x='293.81' y='333.70' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.32</text>
+<text x='293.81' y='292.67' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.36</text>
+<text x='293.81' y='251.64' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.09</text>
+<text x='293.81' y='210.61' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='293.81' y='169.58' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.37</text>
+<text x='293.81' y='128.55' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='228.94' y='374.74' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.34</text>
+<text x='228.94' y='333.70' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
+<text x='228.94' y='292.67' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.33</text>
+<text x='228.94' y='251.64' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.12</text>
+<text x='228.94' y='210.61' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.06</text>
+<text x='228.94' y='169.58' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.85</text>
+<text x='228.94' y='128.55' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.64</text>
+<text x='228.94' y='87.51' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='164.07' y='374.74' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.99</text>
+<text x='164.07' y='333.70' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='164.07' y='292.67' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.34</text>
+<text x='164.07' y='251.64' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.54</text>
+<text x='164.07' y='210.61' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='164.07' y='169.58' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
+<text x='164.07' y='128.55' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.41</text>
+<text x='164.07' y='87.51' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.38</text>
+<text x='164.07' y='46.48' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>1</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='99.34,424.10 99.34,22.78 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<text x='94.41' y='405.43' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.71px' lengthAdjust='spacingAndGlyphs'>wis</text>
-<text x='94.41' y='360.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='55.28px' lengthAdjust='spacingAndGlyphs'>overprediction</text>
-<text x='94.41' y='315.95' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='60.67px' lengthAdjust='spacingAndGlyphs'>underprediction</text>
-<text x='94.41' y='271.21' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='40.12px' lengthAdjust='spacingAndGlyphs'>dispersion</text>
-<text x='94.41' y='226.47' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='16.15px' lengthAdjust='spacingAndGlyphs'>bias</text>
-<text x='94.41' y='181.73' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='50.89px' lengthAdjust='spacingAndGlyphs'>coverage_50</text>
-<text x='94.41' y='136.99' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='50.89px' lengthAdjust='spacingAndGlyphs'>coverage_90</text>
-<text x='94.41' y='92.25' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='76.33px' lengthAdjust='spacingAndGlyphs'>coverage_deviation</text>
-<text x='94.41' y='47.51' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='43.55px' lengthAdjust='spacingAndGlyphs'>ae_median</text>
-<polyline points='96.60,402.40 99.34,402.40 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='96.60,357.66 99.34,357.66 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='96.60,312.92 99.34,312.92 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='96.60,268.18 99.34,268.18 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='96.60,223.44 99.34,223.44 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='96.60,178.70 99.34,178.70 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='96.60,133.96 99.34,133.96 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='96.60,89.22 99.34,89.22 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='96.60,44.48 99.34,44.48 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='99.34,424.10 714.52,424.10 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='132.60,426.84 132.60,424.10 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='201.18,426.84 201.18,424.10 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='269.76,426.84 269.76,424.10 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='338.35,426.84 338.35,424.10 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='406.93,426.84 406.93,424.10 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='475.51,426.84 475.51,424.10 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='544.09,426.84 544.09,424.10 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='612.68,426.84 612.68,424.10 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='681.26,426.84 681.26,424.10 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<text transform='translate(138.66,429.03) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='43.55px' lengthAdjust='spacingAndGlyphs'>ae_median</text>
-<text transform='translate(207.24,429.03) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='76.33px' lengthAdjust='spacingAndGlyphs'>coverage_deviation</text>
-<text transform='translate(275.82,429.03) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='50.89px' lengthAdjust='spacingAndGlyphs'>coverage_90</text>
-<text transform='translate(344.40,429.03) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='50.89px' lengthAdjust='spacingAndGlyphs'>coverage_50</text>
-<text transform='translate(412.99,429.03) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='16.15px' lengthAdjust='spacingAndGlyphs'>bias</text>
-<text transform='translate(481.57,429.03) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='40.12px' lengthAdjust='spacingAndGlyphs'>dispersion</text>
-<text transform='translate(550.15,429.03) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='60.67px' lengthAdjust='spacingAndGlyphs'>underprediction</text>
-<text transform='translate(618.73,429.03) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='55.28px' lengthAdjust='spacingAndGlyphs'>overprediction</text>
-<text transform='translate(687.31,429.03) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.71px' lengthAdjust='spacingAndGlyphs'>wis</text>
-<image width='86.40' height='17.28' x='393.37' y='534.40' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAAABCAYAAABkOJMpAAAAi0lEQVQ4jc2Q0Q0CMQxDn/cfiB2Ygk3MR9pcK3pXgkDiq5GTPDvV7f6wAElIAPGOWshqWtNbnfMC5W4szVpjjOzOyHr2YOG3Z895WNyyZvf7qzle/4UhB3ZAbcDxmqPuvdXcaa8wl55XjHHuLNu7uQv+pf8o7H503z95/Zh3yT407/wM3uRx+n2n/wR2mBP8oZBbpQAAAABJRU5ErkJggg=='/>
-<text x='418.55' y='563.21' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='449.09' y='563.21' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
-<text x='479.63' y='563.21' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='334.09' y='553.50' style='font-size: 11.00px; font-family: sans;' textLength='53.80px' lengthAdjust='spacingAndGlyphs'>Correlation</text>
-<line x1='418.55' y1='551.68' x2='418.55' y2='548.22' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='449.09' y1='551.68' x2='449.09' y2='548.22' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='479.63' y1='551.68' x2='479.63' y2='548.22' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='418.55' y1='537.85' x2='418.55' y2='534.40' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='449.09' y1='537.85' x2='449.09' y2='534.40' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='479.63' y1='537.85' x2='479.63' y2='534.40' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<text x='99.34' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='97.60px' lengthAdjust='spacingAndGlyphs'>plot__correlation</text>
+<polyline points='132.60,390.84 132.60,22.78 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<text x='127.67' y='373.97' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.71px' lengthAdjust='spacingAndGlyphs'>wis</text>
+<text x='127.67' y='332.93' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='55.28px' lengthAdjust='spacingAndGlyphs'>overprediction</text>
+<text x='127.67' y='291.90' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='60.67px' lengthAdjust='spacingAndGlyphs'>underprediction</text>
+<text x='127.67' y='250.87' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='40.12px' lengthAdjust='spacingAndGlyphs'>dispersion</text>
+<text x='127.67' y='209.84' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='16.15px' lengthAdjust='spacingAndGlyphs'>bias</text>
+<text x='127.67' y='168.81' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='84.16px' lengthAdjust='spacingAndGlyphs'>interval_coverage_50</text>
+<text x='127.67' y='127.78' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='84.16px' lengthAdjust='spacingAndGlyphs'>interval_coverage_90</text>
+<text x='127.67' y='86.74' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='109.60px' lengthAdjust='spacingAndGlyphs'>interval_coverage_deviation</text>
+<text x='127.67' y='45.71' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='43.55px' lengthAdjust='spacingAndGlyphs'>ae_median</text>
+<polyline points='129.86,370.94 132.60,370.94 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='129.86,329.91 132.60,329.91 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='129.86,288.87 132.60,288.87 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='129.86,247.84 132.60,247.84 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='129.86,206.81 132.60,206.81 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='129.86,165.78 132.60,165.78 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='129.86,124.75 132.60,124.75 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='129.86,83.72 132.60,83.72 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='129.86,42.68 132.60,42.68 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='132.60,390.84 714.52,390.84 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='164.07,393.58 164.07,390.84 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='228.94,393.58 228.94,390.84 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='293.81,393.58 293.81,390.84 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='358.69,393.58 358.69,390.84 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='423.56,393.58 423.56,390.84 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='488.43,393.58 488.43,390.84 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='553.31,393.58 553.31,390.84 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='618.18,393.58 618.18,390.84 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='683.06,393.58 683.06,390.84 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<text transform='translate(170.12,395.77) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='43.55px' lengthAdjust='spacingAndGlyphs'>ae_median</text>
+<text transform='translate(235.00,395.77) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='109.60px' lengthAdjust='spacingAndGlyphs'>interval_coverage_deviation</text>
+<text transform='translate(299.87,395.77) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='84.16px' lengthAdjust='spacingAndGlyphs'>interval_coverage_90</text>
+<text transform='translate(364.74,395.77) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='84.16px' lengthAdjust='spacingAndGlyphs'>interval_coverage_50</text>
+<text transform='translate(429.62,395.77) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='16.15px' lengthAdjust='spacingAndGlyphs'>bias</text>
+<text transform='translate(494.49,395.77) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='40.12px' lengthAdjust='spacingAndGlyphs'>dispersion</text>
+<text transform='translate(559.37,395.77) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='60.67px' lengthAdjust='spacingAndGlyphs'>underprediction</text>
+<text transform='translate(624.24,395.77) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='55.28px' lengthAdjust='spacingAndGlyphs'>overprediction</text>
+<text transform='translate(689.11,395.77) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.71px' lengthAdjust='spacingAndGlyphs'>wis</text>
+<image width='86.40' height='17.28' x='410.00' y='534.40' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAAABCAYAAABkOJMpAAAAi0lEQVQ4jc2Q0Q0CMQxDn/cfiB2Ygk3MR9pcK3pXgkDiq5GTPDvV7f6wAElIAPGOWshqWtNbnfMC5W4szVpjjOzOyHr2YOG3Z895WNyyZvf7qzle/4UhB3ZAbcDxmqPuvdXcaa8wl55XjHHuLNu7uQv+pf8o7H503z95/Zh3yT407/wM3uRx+n2n/wR2mBP8oZBbpQAAAABJRU5ErkJggg=='/>
+<text x='435.19' y='563.21' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='465.72' y='563.21' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='496.26' y='563.21' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='350.72' y='553.50' style='font-size: 11.00px; font-family: sans;' textLength='53.80px' lengthAdjust='spacingAndGlyphs'>Correlation</text>
+<line x1='435.19' y1='551.68' x2='435.19' y2='548.22' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='465.72' y1='551.68' x2='465.72' y2='548.22' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='496.26' y1='551.68' x2='496.26' y2='548.22' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='435.19' y1='537.85' x2='435.19' y2='534.40' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='465.72' y1='537.85' x2='465.72' y2='534.40' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='496.26' y1='537.85' x2='496.26' y2='534.40' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='132.60' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='97.60px' lengthAdjust='spacingAndGlyphs'>plot__correlation</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/plot_score_table/plot-score-table.svg
+++ b/tests/testthat/_snaps/plot_score_table/plot-score-table.svg
@@ -20,113 +20,113 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMTI1LjI1fDcxNC41MnwyMi43OHw0NzYuNjY='>
-    <rect x='125.25' y='22.78' width='589.27' height='453.88' />
+  <clipPath id='cpMTI1LjI1fDcxNC41MnwyMi43OHw0NDMuNDA='>
+    <rect x='125.25' y='22.78' width='589.27' height='420.62' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMTI1LjI1fDcxNC41MnwyMi43OHw0NzYuNjY=)'>
-<rect x='125.25' y='249.72' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFA093;' />
-<rect x='125.25' y='363.19' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FE9587;' />
-<rect x='125.25' y='22.78' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FE9587;' />
-<rect x='125.25' y='136.25' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
-<rect x='190.73' y='249.72' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFADA0;' />
-<rect x='190.73' y='363.19' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FC8B7D;' />
-<rect x='190.73' y='22.78' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9C8E;' />
-<rect x='190.73' y='136.25' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
-<rect x='256.20' y='249.72' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFCEC5;' />
-<rect x='256.20' y='363.19' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8173;' />
-<rect x='256.20' y='22.78' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFCEC5;' />
-<rect x='256.20' y='136.25' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
-<rect x='321.67' y='249.72' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFAEA2;' />
-<rect x='321.67' y='363.19' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFAEA2;' />
-<rect x='321.67' y='22.78' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FB8375;' />
-<rect x='321.67' y='136.25' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
-<rect x='387.15' y='249.72' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFBFB;' />
-<rect x='387.15' y='363.19' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFA295;' />
-<rect x='387.15' y='22.78' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E5ECF4;' />
-<rect x='387.15' y='136.25' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2F5F9;' />
-<rect x='452.62' y='249.72' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
-<rect x='452.62' y='363.19' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC0B6;' />
-<rect x='452.62' y='22.78' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
-<rect x='452.62' y='136.25' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC0B6;' />
-<rect x='518.10' y='249.72' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF988A;' />
-<rect x='518.10' y='363.19' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF988A;' />
-<rect x='518.10' y='22.78' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
-<rect x='518.10' y='136.25' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF988A;' />
-<rect x='583.57' y='249.72' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC7BE;' />
-<rect x='583.57' y='363.19' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFDFC;' />
-<rect x='583.57' y='22.78' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A1BAD7;' />
-<rect x='583.57' y='136.25' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E0E8F2;' />
-<rect x='649.05' y='249.72' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC1B7;' />
-<rect x='649.05' y='363.19' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
-<rect x='649.05' y='22.78' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC1B7;' />
-<rect x='649.05' y='136.25' width='65.47' height='113.47' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
-<text x='157.99' y='310.26' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>9000</text>
-<text x='157.99' y='423.73' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='30.70px' lengthAdjust='spacingAndGlyphs'>10000</text>
-<text x='157.99' y='83.32' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='30.70px' lengthAdjust='spacingAndGlyphs'>10000</text>
-<text x='157.99' y='196.79' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='12.28px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text x='223.46' y='310.26' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>5000</text>
-<text x='223.46' y='423.73' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>7000</text>
-<text x='223.46' y='83.32' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>6000</text>
-<text x='223.46' y='196.79' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>9</text>
-<text x='288.94' y='310.26' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>2000</text>
-<text x='288.94' y='423.73' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>5000</text>
-<text x='288.94' y='83.32' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>2000</text>
-<text x='288.94' y='196.79' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='12.28px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='354.41' y='310.26' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>2000</text>
-<text x='354.41' y='423.73' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>2000</text>
-<text x='354.41' y='83.32' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>3000</text>
-<text x='354.41' y='196.79' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='12.28px' lengthAdjust='spacingAndGlyphs'>30</text>
-<text x='419.89' y='310.26' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='27.63px' lengthAdjust='spacingAndGlyphs'>0.008</text>
-<text x='419.89' y='423.73' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>
-<text x='419.89' y='83.32' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.04</text>
-<text x='419.89' y='196.79' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.02</text>
-<text x='485.36' y='310.26' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.6</text>
-<text x='485.36' y='423.73' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.5</text>
-<text x='485.36' y='83.32' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.4</text>
-<text x='485.36' y='196.79' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.5</text>
-<text x='550.83' y='310.26' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.9</text>
-<text x='550.83' y='423.73' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.9</text>
-<text x='550.83' y='83.32' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.8</text>
-<text x='550.83' y='196.79' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.9</text>
-<text x='616.31' y='310.26' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.05</text>
-<text x='616.31' y='423.73' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='27.63px' lengthAdjust='spacingAndGlyphs'>0.002</text>
-<text x='616.31' y='83.32' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.06</text>
-<text x='616.31' y='196.79' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.02</text>
-<text x='681.78' y='310.26' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='30.70px' lengthAdjust='spacingAndGlyphs'>10000</text>
-<text x='681.78' y='423.73' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='30.70px' lengthAdjust='spacingAndGlyphs'>20000</text>
-<text x='681.78' y='83.32' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='30.70px' lengthAdjust='spacingAndGlyphs'>10000</text>
-<text x='681.78' y='196.79' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='12.28px' lengthAdjust='spacingAndGlyphs'>80</text>
+<g clip-path='url(#cpMTI1LjI1fDcxNC41MnwyMi43OHw0NDMuNDA=)'>
+<rect x='125.25' y='233.09' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFA093;' />
+<rect x='125.25' y='338.24' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FE9587;' />
+<rect x='125.25' y='22.78' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FE9587;' />
+<rect x='125.25' y='127.94' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='190.73' y='233.09' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFADA0;' />
+<rect x='190.73' y='338.24' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FC8B7D;' />
+<rect x='190.73' y='22.78' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9C8E;' />
+<rect x='190.73' y='127.94' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='256.20' y='233.09' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFCEC5;' />
+<rect x='256.20' y='338.24' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8173;' />
+<rect x='256.20' y='22.78' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFCEC5;' />
+<rect x='256.20' y='127.94' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='321.67' y='233.09' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFAEA2;' />
+<rect x='321.67' y='338.24' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFAEA2;' />
+<rect x='321.67' y='22.78' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FB8375;' />
+<rect x='321.67' y='127.94' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='387.15' y='233.09' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFBFB;' />
+<rect x='387.15' y='338.24' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFA295;' />
+<rect x='387.15' y='22.78' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E5ECF4;' />
+<rect x='387.15' y='127.94' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2F5F9;' />
+<rect x='452.62' y='233.09' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
+<rect x='452.62' y='338.24' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC0B6;' />
+<rect x='452.62' y='22.78' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='452.62' y='127.94' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC0B6;' />
+<rect x='518.10' y='233.09' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF988A;' />
+<rect x='518.10' y='338.24' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF988A;' />
+<rect x='518.10' y='22.78' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='518.10' y='127.94' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF988A;' />
+<rect x='583.57' y='233.09' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC7BE;' />
+<rect x='583.57' y='338.24' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFDFC;' />
+<rect x='583.57' y='22.78' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A1BAD7;' />
+<rect x='583.57' y='127.94' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E0E8F2;' />
+<rect x='649.05' y='233.09' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC1B7;' />
+<rect x='649.05' y='338.24' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FA8072;' />
+<rect x='649.05' y='22.78' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC1B7;' />
+<rect x='649.05' y='127.94' width='65.47' height='105.15' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='157.99' y='289.47' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>9000</text>
+<text x='157.99' y='394.62' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='30.70px' lengthAdjust='spacingAndGlyphs'>10000</text>
+<text x='157.99' y='79.16' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='30.70px' lengthAdjust='spacingAndGlyphs'>10000</text>
+<text x='157.99' y='184.31' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='12.28px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='223.46' y='289.47' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>5000</text>
+<text x='223.46' y='394.62' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>7000</text>
+<text x='223.46' y='79.16' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>6000</text>
+<text x='223.46' y='184.31' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='6.14px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='288.94' y='289.47' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>2000</text>
+<text x='288.94' y='394.62' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>5000</text>
+<text x='288.94' y='79.16' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>2000</text>
+<text x='288.94' y='184.31' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='12.28px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='354.41' y='289.47' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>2000</text>
+<text x='354.41' y='394.62' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>2000</text>
+<text x='354.41' y='79.16' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='24.56px' lengthAdjust='spacingAndGlyphs'>3000</text>
+<text x='354.41' y='184.31' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='12.28px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='419.89' y='289.47' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='27.63px' lengthAdjust='spacingAndGlyphs'>0.008</text>
+<text x='419.89' y='394.62' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='419.89' y='79.16' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.04</text>
+<text x='419.89' y='184.31' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.02</text>
+<text x='485.36' y='289.47' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='485.36' y='394.62' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='485.36' y='79.16' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='485.36' y='184.31' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='550.83' y='289.47' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='550.83' y='394.62' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='550.83' y='79.16' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='550.83' y='184.31' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='15.35px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='616.31' y='289.47' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='21.49px' lengthAdjust='spacingAndGlyphs'>0.05</text>
+<text x='616.31' y='394.62' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='27.63px' lengthAdjust='spacingAndGlyphs'>0.002</text>
+<text x='616.31' y='79.16' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.06</text>
+<text x='616.31' y='184.31' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='25.16px' lengthAdjust='spacingAndGlyphs'>-0.02</text>
+<text x='681.78' y='289.47' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='30.70px' lengthAdjust='spacingAndGlyphs'>10000</text>
+<text x='681.78' y='394.62' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='30.70px' lengthAdjust='spacingAndGlyphs'>20000</text>
+<text x='681.78' y='79.16' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='30.70px' lengthAdjust='spacingAndGlyphs'>10000</text>
+<text x='681.78' y='184.31' text-anchor='middle' style='font-size: 11.04px; font-family: sans;' textLength='12.28px' lengthAdjust='spacingAndGlyphs'>80</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='125.25,476.66 125.25,22.78 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<text x='120.32' y='422.96' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='96.87px' lengthAdjust='spacingAndGlyphs'>EuroCOVIDhub-baseline</text>
-<text x='120.32' y='309.49' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='102.25px' lengthAdjust='spacingAndGlyphs'>EuroCOVIDhub-ensemble</text>
-<text x='120.32' y='196.02' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='76.32px' lengthAdjust='spacingAndGlyphs'>UMass-MechBayes</text>
-<text x='120.32' y='82.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='85.61px' lengthAdjust='spacingAndGlyphs'>epiforecasts-EpiNow2</text>
-<polyline points='122.51,419.93 125.25,419.93 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='122.51,306.46 125.25,306.46 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='122.51,192.99 125.25,192.99 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='122.51,79.52 125.25,79.52 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='125.25,476.66 714.52,476.66 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='157.99,479.40 157.99,476.66 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='223.46,479.40 223.46,476.66 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='288.94,479.40 288.94,476.66 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='354.41,479.40 354.41,476.66 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='419.89,479.40 419.89,476.66 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='485.36,479.40 485.36,476.66 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='550.83,479.40 550.83,476.66 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='616.31,479.40 616.31,476.66 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polyline points='681.78,479.40 681.78,476.66 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<text transform='translate(164.05,481.59) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.71px' lengthAdjust='spacingAndGlyphs'>wis</text>
-<text transform='translate(229.52,481.59) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='55.28px' lengthAdjust='spacingAndGlyphs'>overprediction</text>
-<text transform='translate(294.99,481.59) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='60.67px' lengthAdjust='spacingAndGlyphs'>underprediction</text>
-<text transform='translate(360.47,481.59) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='40.12px' lengthAdjust='spacingAndGlyphs'>dispersion</text>
-<text transform='translate(425.94,481.59) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='16.15px' lengthAdjust='spacingAndGlyphs'>bias</text>
-<text transform='translate(491.42,481.59) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='50.89px' lengthAdjust='spacingAndGlyphs'>coverage_50</text>
-<text transform='translate(556.89,481.59) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='50.89px' lengthAdjust='spacingAndGlyphs'>coverage_90</text>
-<text transform='translate(622.37,481.59) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='76.33px' lengthAdjust='spacingAndGlyphs'>coverage_deviation</text>
-<text transform='translate(687.84,481.59) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='43.55px' lengthAdjust='spacingAndGlyphs'>ae_median</text>
+<polyline points='125.25,443.40 125.25,22.78 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<text x='120.32' y='393.85' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='96.87px' lengthAdjust='spacingAndGlyphs'>EuroCOVIDhub-baseline</text>
+<text x='120.32' y='288.70' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='102.25px' lengthAdjust='spacingAndGlyphs'>EuroCOVIDhub-ensemble</text>
+<text x='120.32' y='183.54' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='76.32px' lengthAdjust='spacingAndGlyphs'>UMass-MechBayes</text>
+<text x='120.32' y='78.39' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='85.61px' lengthAdjust='spacingAndGlyphs'>epiforecasts-EpiNow2</text>
+<polyline points='122.51,390.82 125.25,390.82 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='122.51,285.67 125.25,285.67 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='122.51,180.51 125.25,180.51 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='122.51,75.36 125.25,75.36 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='125.25,443.40 714.52,443.40 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='157.99,446.14 157.99,443.40 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='223.46,446.14 223.46,443.40 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='288.94,446.14 288.94,443.40 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='354.41,446.14 354.41,443.40 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='419.89,446.14 419.89,443.40 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='485.36,446.14 485.36,443.40 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='550.83,446.14 550.83,443.40 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='616.31,446.14 616.31,443.40 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<polyline points='681.78,446.14 681.78,443.40 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
+<text transform='translate(164.05,448.33) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.71px' lengthAdjust='spacingAndGlyphs'>wis</text>
+<text transform='translate(229.52,448.33) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='55.28px' lengthAdjust='spacingAndGlyphs'>overprediction</text>
+<text transform='translate(294.99,448.33) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='60.67px' lengthAdjust='spacingAndGlyphs'>underprediction</text>
+<text transform='translate(360.47,448.33) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='40.12px' lengthAdjust='spacingAndGlyphs'>dispersion</text>
+<text transform='translate(425.94,448.33) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='16.15px' lengthAdjust='spacingAndGlyphs'>bias</text>
+<text transform='translate(491.42,448.33) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='84.16px' lengthAdjust='spacingAndGlyphs'>interval_coverage_50</text>
+<text transform='translate(556.89,448.33) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='84.16px' lengthAdjust='spacingAndGlyphs'>interval_coverage_90</text>
+<text transform='translate(622.37,448.33) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='109.60px' lengthAdjust='spacingAndGlyphs'>interval_coverage_deviation</text>
+<text transform='translate(687.84,448.33) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='43.55px' lengthAdjust='spacingAndGlyphs'>ae_median</text>
 <text x='125.25' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='96.88px' lengthAdjust='spacingAndGlyphs'>plot_score_table</text>
 </g>
 </svg>

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -4,10 +4,12 @@ library(data.table)
 suppressMessages(library(magrittr))
 
 metrics_no_cov <- rules_quantile(
-  exclude = c("coverage_50", "coverage_90", "coverage_deviation")
+  exclude = c("interval_coverage_50", "interval_coverage_90",
+              "interval_coverage_deviation")
 )
 metrics_no_cov_no_ae <- rules_quantile(
-  exclude = c("coverage_50", "coverage_90", "coverage_deviation", "ae_median")
+  exclude = c("interval_coverage_50", "interval_coverage_90",
+              "interval_coverage_deviation", "ae_median")
 )
 
 


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #436.

We previously used the word "coverage" to describe interval coverage. This sensationally boring PR
- replaces instances of "coverage" both in the code and in the documentation to make this distinction a bit clearer. 
- updates the default scoring rules
- makes a few changes to plotting functions (`plot_score_table()`) and to `available_metrics()`. `available_metrics()` needs to be removed at some point in the future and `plot_score_table()` also needs an update, but this should be done in a different PR

Mentioning a few unrelated issues that came up: 
- There are some suggestions for code refactoring in `interval_coverage_sample()`. These should be moved to an issue. Alternatively, (and maybe preferably?) the function should be removed altogether. We're not using it in `score()` (i.e. it is not part of the default functions for sample-based forecasts). For data.frame-based forecasts, our preferred workflow is to transform forecasts to a quantile format explicitly and then e.g. use `add_coverage()`. We don't have any equivalent workflow for functions in a matrix-based format. But then again maybe we don't need to. We could still think about a `sample_to_quantile.numeric()` function which would transform a matrix of samples to a data.frame in a quantile-based format. 
- We'll have to rethink `plot_score_table()`. The function currently uses different colour scales depending on whether a score is "low is better" or "zero is better" or something else. Since we now allow users to supply their own functions that won't work anymore. 


## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
