### PR TITLE
Fix error message for `interval_coverage_quantile()`

### DIFF
--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -241,7 +241,8 @@ interval_coverage_quantile <- function(observed, predicted, quantile, range = 50
   if (!all(necessary_quantiles %in% quantile)) {
     warning(
       "To compute the interval coverage for a range of ", range,
-      "%, the quantiles ", necessary_quantiles, " are required. Returning `NA`."
+      "%, the quantiles `", toString(necessary_quantiles),
+      "` are required. Returning `NA`."
     )
     return(NA)
   }


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

The previous version had a typo: 
```
1: In (function (observed, predicted, quantile, range = 50)  :
  To compute the interval coverage for a range of 50%, the quantiles 0.250.75 are required. Returning `NA`.
```

This PR fixes this so that the message now reads:
```
1: In (function (observed, predicted, quantile, range = 50)  :
  To compute the interval coverage for a range of 50%, the quantiles `0.25, 0.75` are required. Returning `NA`.
```

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] I have built the package locally and run rebuilt docs using roxygen2.
- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
