### PR TITLE
Issue #535: Create pkgdown docs for stable and dev versions

### DIFF
--- a/.github/workflows/render_readme.yaml
+++ b/.github/workflows/render_readme.yaml
@@ -11,6 +11,7 @@ on:
   push:
     paths:
       - 'README.Rmd'
+      - DESCRIPTION
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scoringutils
 Title: Utilities for Scoring and Assessing Predictions
-Version: 1.2.2
+Version: 1.2.2.9000
 Language: en-GB
 Authors@R: c(
     person(given = "Nikos",

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,7 @@ The update introduces breaking changes. If you want to keep using the older vers
 - added documentation for the return value of `summarise_scores()`.
 - Removed abs_error and squared_error from the package in favour of `Metrics::ae` and `Metrics::se`. 
 - Added unit tests for `interval_coverage_quantile()` and `interval_coverage_dev_quantile()` in order to make sure that the functions provide the correct warnings when insufficient quantiles are provided.
+- Documentation pkgdown pages are now created both for the stable and dev versions.
 
 # scoringutils 1.2.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# scoringutils 2.0.0
+# scoringutils 1.2.2.9000
 
 This major update and addresses a variety of comments made by reviewers from the Journal of Statistical Software (see preprint of the manuscript [here](https://arxiv.org/abs/2205.07090)).
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -37,17 +37,15 @@ if (devel) {
   cat(
     "**Note**: ",
     "This documentation refers to the development version of `scoringutils`. ",
-    "For the latest CRAN release please refer to the ",
-    "[documentation of the stable version]",
+    "You can also view the [documentation of the stable version]",
     "(https://epiforecasts.io/scoringutils).",
     sep = ""
   )
 } else {
   cat(
     "**Note**: ",
-    "This documentation refers to the CRAN version of `scoringutils`. ",
-    "For the version on GitHub please refer to the ",
-    "[documentation of the development version]",
+    "This documentation refers to the stable version of `scoringutils`. ",
+    "You can also view the [documentation of the development version]",
     "(https://epiforecasts.io/scoringutils/dev).",
     sep = ""
   )

--- a/README.Rmd
+++ b/README.Rmd
@@ -26,6 +26,33 @@ library(magrittr)
 library(data.table)
 library(ggplot2)
 library(knitr)
+
+## code to determine version inspired by [pkgdown:::dev_mode_auto()]
+version <- packageVersion("scoringutils")
+devel <- length(unclass(package_version(version))[[1]]) > 3
+```
+
+```{r note_dev, results = 'asis', echo = FALSE}
+if (devel) {
+  cat(
+    "**Note**: ",
+    "This documentation refers to the development version of `scoringutils`. ",
+    "For the latest CRAN release please refer to the ",
+    "[documentation of the stable version]",
+    "(https://epiforecasts.io/scoringutils).",
+    sep = ""
+  )
+} else {
+  cat(
+    "**Note**: ",
+    "This documentation refers to the CRAN version of `scoringutils`. ",
+    "For the version on GitHub please refer to the ",
+    "[documentation of the development version]",
+    "(https://epiforecasts.io/scoringutils/dev).",
+    sep = ""
+  )
+}
+cat("\n\n")
 ```
 
 The `scoringutils` package provides a collection of metrics and proper scoring rules and aims to make it simple to score probabilistic forecasts against observed values. 


### PR DESCRIPTION
## Description

This PR closes #535.

It does so by setting the development version (four components) as [done in the `usethis` package](https://usethis.r-lib.org/reference/use_version.html).

It also adds a note for the user to clarify which version of the documentation they're looking at. This is mostly to help people arriving from a search engine.

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] I have built the package locally and run rebuilt docs using roxygen2.
- [X] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [X] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.