### PR TITLE
Issue 557: Fix small numerical issue in sample_to_quantile()

### DIFF
--- a/R/utils_data_handling.R
+++ b/R/utils_data_handling.R
@@ -107,6 +107,8 @@ sample_to_quantile <- function(data,
   reserved_columns <- c("predicted", "sample_id")
   by <- setdiff(colnames(data), reserved_columns)
 
+  quantiles <- unique(round(c(quantiles, 1 - quantiles), digits = 10))
+
   data <- data[, .(quantile = quantiles,
                    predicted = quantile(x = predicted, prob = ..quantiles,
                                         type = ..type, na.rm = TRUE)),

--- a/tests/testthat/test-utils_data_handling.R
+++ b/tests/testthat/test-utils_data_handling.R
@@ -109,6 +109,16 @@ test_that("sample_to_quantiles works", {
 
 })
 
+test_that("sample_to_quantiles issue 557 fix", {
+
+  out <- example_integer %>%
+    sample_to_quantile(
+      quantiles = c(0.01, 0.025, seq(0.05, 0.95, 0.05), 0.975, 0.99)
+    ) %>%
+    score()
+
+  expect_equal(any(is.na(out$interval_coverage_deviation)), FALSE)
+})
 
 
 test_that("sample_to_range_long works", {


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes https://github.com/epiforecasts/scoringutils/issues/543

The problem is caused by concatenating a `seq` of numbers inside a vector. Later down the line in the metric calculations, a function is checking that the quantile vector is symmetrical by looking at whether x == 1- x and finding an error. There is a small numerical difference between x and 1 - x as you can see below. Rounding at 10 digits fixes this and the example in the issue runs as expected.

```
> x <- c(0.01, 0.025, seq(0.05, 0.95, 0.05), 0.975, 0.99)
> x[1]
[1] 0.01
> x[23]
[1] 0.99
> x[1] == 1 - x[23]
[1] FALSE
> x[1] - (1 - x[23])
[1] -8.673617e-18
> round(x[1], 10) == round(1 - x[23], 10)
[1] TRUE
```

In addition to this I now concatenate the user's quantiles vector with 1 - quantile vector. That way if the user accidentally supplies an asymmetrical vector it is made symmetrical. I then round the vector elements as described above and select the unique values.

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
