### PR TITLE
Add current docs link to README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -36,7 +36,7 @@ devel <- length(unclass(package_version(version))[[1]]) > 3
 if (devel) {
   cat(
     "**Note**: ",
-    "This documentation refers to the development version of `scoringutils`. ",
+    "[This documentation](https://epiforecasts.io/scoringutils/dev) refers to the development version of `scoringutils`. ",
     "You can also view the [documentation of the stable version]",
     "(https://epiforecasts.io/scoringutils).",
     sep = ""
@@ -44,7 +44,7 @@ if (devel) {
 } else {
   cat(
     "**Note**: ",
-    "This documentation refers to the stable version of `scoringutils`. ",
+    "[This documentation](https://epiforecasts.io/scoringutils) refers to the stable version of `scoringutils`. ",
     "You can also view the [documentation of the development version]",
     "(https://epiforecasts.io/scoringutils/dev).",
     sep = ""

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ version](https://img.shields.io/github/r-package/v/epiforecasts/scoringutils)
 downloads](http://cranlogs.r-pkg.org/badges/grand-total/scoringutils)](https://cran.r-project.org/package=scoringutils)
 <!-- badges: end -->
 
-**Note**: This documentation refers to the development version of
-`scoringutils`. You can also view the [documentation of the stable
+**Note**: [This documentation](https://epiforecasts.io/scoringutils/dev)
+refers to the development version of `scoringutils`. You can also view
+the [documentation of the stable
 version](https://epiforecasts.io/scoringutils).
 
 The `scoringutils` package provides a collection of metrics and proper


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

In #563 @sbfnk introduced new functionality to post users at the alternative version of the docs to the one they are currently viewing. However, if they are not on the HTML docs then there is currently no link to the current version of the HTML docs that they are looking at. It could be nice if this were the case. 

This PR adds this. I think worth some discussion to check it makes sense .

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] I have built the package locally and run rebuilt docs using roxygen2.
- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
