### PR TITLE
Issue #559: Ensure output of `add_coverage()` is an object of class forecast_quantile

### DIFF
--- a/R/add_coverage.R
+++ b/R/add_coverage.R
@@ -62,7 +62,7 @@ add_coverage <- function(data) {
 
   data[, range := get_range_from_quantile(quantile)]
 
-  data <- merge(interval_data, data, by = unique(c(forecast_unit, "range")))
+  data <- merge(data, interval_data, by = unique(c(forecast_unit, "range")))
   data[, interval_coverage_deviation := interval_coverage - range / 100]
   data[, quantile_coverage := observed <= predicted]
   data[, quantile_coverage_deviation := quantile_coverage - quantile]

--- a/R/convenience-functions.R
+++ b/R/convenience-functions.R
@@ -108,7 +108,7 @@ transform_forecasts <- function(data,
                                 append = TRUE,
                                 label = "log",
                                 ...) {
-  original_data <- as.data.table(data)
+  original_data <- as_forecast(data)
   scale_col_present <- ("scale" %in% colnames(original_data))
 
   # Error handling
@@ -131,10 +131,9 @@ transform_forecasts <- function(data,
 
   if (append) {
     if (scale_col_present) {
-      transformed_data <-
-        data.table::copy(original_data)[scale == "natural"]
+      transformed_data <- copy(original_data)[scale == "natural"]
     } else {
-      transformed_data <- data.table::copy(original_data)
+      transformed_data <- copy(original_data)
       original_data[, scale := "natural"]
     }
     transformed_data[, predicted := fun(predicted, ...)]

--- a/tests/testthat/test-add_coverage.R
+++ b/tests/testthat/test-add_coverage.R
@@ -13,4 +13,12 @@ test_that("add_coverage() works as expected", {
   expect_equal(colnames(cov), c(colnames(example_quantile), required_names))
 
   expect_equal(nrow(cov), nrow(example_quantile))
+
+  # check that
+})
+
+test_that("add_coverage() outputs an object of class forecast_*", {
+  ex <- as_forecast(na.omit(example_quantile))
+  cov <- add_coverage(ex)
+  expect_s3_class(cov, "forecast_quantile")
 })

--- a/tests/testthat/test-as_forecast.R
+++ b/tests/testthat/test-as_forecast.R
@@ -1,0 +1,8 @@
+test_that("Running `as_forecast()` twice returns the same object", {
+  ex <- na.omit(example_continuous)
+
+  expect_identical(
+    as_forecast(as_forecast(ex)),
+    as_forecast(ex)
+  )
+})

--- a/tests/testthat/test-convenience-functions.R
+++ b/tests/testthat/test-convenience-functions.R
@@ -37,6 +37,12 @@ test_that("function transform_forecasts works", {
   expect_equal(four$predicted, compare)
 })
 
+test_that("transform_forecasts() outputs an object of class forecast_*", {
+  ex <- as_forecast(na.omit(example_binary))
+  transformed <- transform_forecasts(ex, fun = identity, append = FALSE)
+  expect_s3_class(transformed, "forecast_binary")
+})
+
 
 # ============================================================================ #
 # `set_forecast_unit()`


### PR DESCRIPTION
## Description

This PR closes #559.

`add_coverage()` used to return a `data.table()`, even if it was called on an object of class `forecast_quantile`. This was due to internal computations: the function `quantile_to_interval()` returns a `data.table` and when merging the newly computed columns with the existing data, a `data.table` was produced. 

In addition, `transform_forecasts()` had a similar issue. This was due to a call to `as.data.table()`. 

This PR 
- switches the order in which the two datasets are passed to `merge()`, solving the issue for `add_coverage()`
- replaces `as.data.table()` with `as_forecast()` for `transform_forecasts()`
- Adds a unit test for both
- Adds an additional, mostly unrelated unit test to check that running `as_forecast()` twice produces the same object. I added this test because `add_coverage()` currently runs `as_forecast()` and I thought it was a good idea to have a test that running `as_forecast()` several times is fine. 
- removes unrelated `data.table::` to make the code style more consistent

Additional thoughts: 
- we should likely check and test all calls to `as.data.table()` in the code. All of these would make an object lose its classes. I opened #587 for this. 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] ~I have added a news item linked to this PR.~
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
