### PR TITLE
Issue #475: rename output columns for pairwise comparisons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@ The update introduces breaking changes. If you want to keep using the older vers
 - Renamed `interval_coverage_quantile()` and `interval_coverage_dev_quantile()` to `interval_coverage()` and `interval_coverage_deviation()`, respectively. Removed `interval_coverage_sample()` as users are now expected to convert to a quantile format first before scoring.
 - Added unit tests for `interval_coverage_quantile()` and `interval_coverage_dev_quantile()` in order to make sure that the functions provide the correct warnings when insufficient quantiles are provided.
 - Documentation pkgdown pages are now created both for the stable and dev versions.
+- Output columns for pairwise comparisons have been renamed to contain the name of the metric used for comparing.
 
 # scoringutils 1.2.2
 

--- a/R/get_-functions.R
+++ b/R/get_-functions.R
@@ -213,8 +213,7 @@ get_protected_columns <- function(data = NULL) {
     "interval_coverage", "interval_coverage_deviation",
     "quantile_coverage", "quantile_coverage_deviation",
     available_metrics(),
-    paste(available_metrics(), "relative_skill", sep = "_"),
-    paste(available_metrics(), "scaled_relative_skill", sep = "_"),
+    grep("_relative_skill$", names(data), value = TRUE),
     grep("coverage_", names(data), fixed = TRUE, value = TRUE)
   )
 

--- a/R/get_-functions.R
+++ b/R/get_-functions.R
@@ -209,10 +209,12 @@ get_protected_columns <- function(data = NULL) {
 
   protected_columns <- c(
     "predicted", "observed", "sample_id", "quantile", "upper", "lower",
-    "pit_value", "range", "boundary", "relative_skill", "scaled_rel_skill",
+    "pit_value", "range", "boundary",
     "interval_coverage", "interval_coverage_deviation",
     "quantile_coverage", "quantile_coverage_deviation",
     available_metrics(),
+    paste(available_metrics(), "relative_skill", sep = "_"),
+    paste(available_metrics(), "scaled_relative_skill", sep = "_"),
     grep("coverage_", names(data), fixed = TRUE, value = TRUE)
   )
 

--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -237,8 +237,7 @@ pairwise_comparison_one_group <- function(scores,
   # calculate relative skill as geometric mean
   # small theta is again better (assuming that the score is negatively oriented)
   result[, `:=`(
-    theta = geometric_mean(ratio),
-    rel_to_baseline = NA_real_
+    theta = geometric_mean(ratio)
   ),
   by = "model"
   ]
@@ -261,9 +260,18 @@ pairwise_comparison_one_group <- function(scores,
 
   # rename ratio to mean_scores_ratio
   data.table::setnames(out,
-    old = c("ratio", "theta", "rel_to_baseline"),
-    new = c("mean_scores_ratio", "relative_skill", "scaled_rel_skill")
+    old = c("ratio", "theta"),
+    new = c(
+      "mean_scores_ratio",
+      paste(metric, "relative_skill", sep = "_")
+    )
   )
+  if (!is.null(baseline)) {
+    data.table::setnames(out,
+      old = "rel_to_baseline",
+      new = paste(metric, "scaled_relative_skill", sep = "_")
+    )
+  }
 
   return(out[])
 }

--- a/R/plot.R
+++ b/R/plot.R
@@ -715,7 +715,10 @@ plot_pairwise_comparison <- function(comparison_result,
                                      type = c("mean_scores_ratio", "pval")) {
   comparison_result <- data.table::as.data.table(comparison_result)
 
-  comparison_result[, model := reorder(model, -relative_skill)]
+  relative_skill_metric <- grep(
+    "_relative_skill$", colnames(comparison_result), value = TRUE
+  )
+  comparison_result[, model := reorder(model, -get(relative_skill_metric))]
   levels <- levels(comparison_result$model)
 
   get_fill_scale <- function(values, breaks, plot_scales) {

--- a/tests/testthat/test-pairwise_comparison.R
+++ b/tests/testthat/test-pairwise_comparison.R
@@ -75,11 +75,11 @@ test_that("pairwise_comparison() works", {
   # extract the relative_skill values
   relative_skills_without <- eval_without_baseline[, .(
     model = unique(model),
-    relative_skill = unique(relative_skill)
+    relative_skill = unique(wis_relative_skill)
   )]
   relative_skills_with <- eval_with_baseline[, .(
     model = unique(model),
-    relative_skill = unique(scaled_rel_skill)
+    relative_skill = unique(wis_scaled_relative_skill)
   )]
 
   # prepare scores for the code Johannes Bracher wrote
@@ -208,7 +208,7 @@ test_that("pairwise_comparison() works", {
     location == "location_3",
     .(
       model = unique(model),
-      relative_skill = unique(scaled_rel_skill)
+      relative_skill = unique(wis_scaled_relative_skill)
     )
   ]
 
@@ -219,7 +219,7 @@ test_that("pairwise_comparison() work in score() with integer data", {
   eval <- suppressMessages(score(data = example_integer))
   eval_summarised <- summarise_scores(eval, by = "model")
   eval <- add_pairwise_comparison(eval_summarised)
-  expect_true("relative_skill" %in% colnames(eval))
+  expect_true("crps_relative_skill" %in% colnames(eval))
 })
 
 
@@ -227,7 +227,7 @@ test_that("pairwise_comparison() work in score() with binary data", {
   eval <- suppressMessages(score(data = example_binary))
   eval_summarised <- summarise_scores(eval, by = "model")
   eval <- add_pairwise_comparison(eval_summarised)
-  expect_true("relative_skill" %in% colnames(eval))
+  expect_true("brier_score_relative_skill" %in% colnames(eval))
 })
 
 
@@ -246,7 +246,7 @@ test_that("pairwise_comparison() works", {
 
   colnames <- c(
     "model", "compare_against", "mean_scores_ratio",
-    "pval", "adj_pval", "relative_skill", "scaled_rel_skill"
+    "pval", "adj_pval", "wis_relative_skill", "wis_scaled_relative_skill"
   )
 
   expect_true(all(colnames %in% colnames(res)))

--- a/tests/testthat/test-summarise_scores.R
+++ b/tests/testthat/test-summarise_scores.R
@@ -54,7 +54,7 @@ test_that("summarise_scores() can compute relative measures", {
   )
 
   expect_equal(
-    scores_with[, relative_skill],
+    scores_with[, wis_relative_skill],
     c(1.6, 0.81, 0.75, 1.03), tolerance = 0.01
   )
 
@@ -64,7 +64,7 @@ test_that("summarise_scores() can compute relative measures", {
   )
 
   expect_equal(
-    scores_with[, relative_skill],
+    scores_with[, ae_median_relative_skill],
     c(1.6, 0.78, 0.77, 1.04), tolerance = 0.01
   )
 })


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #475.

It renames the output columns for pairwise comparisons to contain the score.

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] I have built the package locally and run rebuilt docs using roxygen2.
- [X] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [X] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
