### PR TITLE
Issue #580 validate output of `set_forecast_unit()` where appropriate

### DIFF
--- a/R/convenience-functions.R
+++ b/R/convenience-functions.R
@@ -242,6 +242,10 @@ set_forecast_unit <- function(data, forecast_unit) {
     forecast_unit <- intersect(forecast_unit, colnames(data))
   }
   keep_cols <- c(get_protected_columns(data), forecast_unit)
-  out <- unique(data[, .SD, .SDcols = keep_cols])[]
+  out <- unique(data[, .SD, .SDcols = keep_cols])
+  # validate that output remains a valid forecast object if input was one before
+  if (is_forecast(out)) {
+    validate_forecast(out)
+  }
   return(out)
 }

--- a/tests/testthat/test-convenience-functions.R
+++ b/tests/testthat/test-convenience-functions.R
@@ -80,6 +80,17 @@ test_that("set_forecast_unit() works on input that's not a data.table", {
   )
 })
 
+test_that("set_forecast_unit() revalidates a forecast object", {
+  obj <- as_forecast(na.omit(example_quantile))
+  expect_no_condition(
+    set_forecast_unit(obj, c("location", "target_end_date", "target_type", "model", "horizon"))
+  )
+  expect_error(
+    set_forecast_unit(obj, c("location", "target_end_date", "target_type", "model")),
+    "There are instances with more than one forecast for the same target."
+  )
+})
+
 
 test_that("function set_forecast_unit() gives warning when column is not there", {
   expect_warning(


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #580 

`set_forecast_unit()` can introduce issues, when called after `as_forecast()`. For example, you could drop columns that are necessary to unambiguously define a single forecast, leading to duplicates. Therefore, `set_forecast_unit()` should validate that an object that was previously an object of class `forecast_` is still one. 
It doesn't validate objects that haven't previously been objects of class `forecast_`. That would mean that `set_forecast_unit()` would have to call `as_forecast()`, but this might lead to errors where there shouldn't be any (also then having two different functions for `set_forecast_unit()` and `as_forecast()` wouldn't make much sense). 

This PR therefore adds a line that checks if the input was an object of class `forecast_*` and if so, runs `validate_foreast()` again. 
I also added additional tests to cover this new case. 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
