### PR TITLE
Issue #620: Allow print method to fail gracefully

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -216,22 +216,44 @@ ensure_data.table <- function(data) {
 #' dat <- as_forecast(example_quantile)
 #' print(dat)
 print.forecast_binary <- function(x, ...) {
-  # Obtain forecast object information for printing
-  forecast_type <- get_forecast_type(x)
+
+  # check whether object passes validation
+  validation <- try(do.call(validate_forecast, list(data = x)), silent = TRUE)
+  if (inherits(validation, "try-error")) {
+    validation_msg <- conditionMessage(attr(validation, "condition"))
+    cat(
+      "The object currently does not pass validation.",
+      "The following error was found:\n"
+    )
+    print(validation_msg)
+  }
+
+  # get forecast type, forecast unit and score columns
+  forecast_type <- try(
+    do.call(get_forecast_type, list(data = x)),
+    silent = TRUE
+  )
+  forecast_unit <- try(
+    do.call(get_forecast_unit, list(data = x)),
+    silent = TRUE
+  )
   score_cols <- get_score_names(x)
-  forecast_unit <- get_forecast_unit(x)
 
   # Print forecast object information
-  cat("Forecast type:\n")
-  print(forecast_type)
+  if (!inherits(forecast_type, "try-error")) {
+    cat("Forecast type:\n")
+    print(forecast_type)
+  }
+
+  if (!inherits(forecast_unit, "try-error")) {
+    cat("\nForecast unit:\n")
+    print(forecast_unit)
+  }
 
   if (!is.null(score_cols)) {
     cat("\nScore columns:\n")
     print(score_cols)
   }
-
-  cat("\nForecast unit:\n")
-  print(forecast_unit)
 
   cat("\n")
   NextMethod(x, ...)

--- a/R/utils.R
+++ b/R/utils.R
@@ -239,18 +239,18 @@ print.forecast_binary <- function(x, ...) {
   score_cols <- get_score_names(x)
 
   # Print forecast object information
-  if (!inherits(forecast_type, "try-error")) {
+  if (inherits(forecast_type, "try-error")) {
+    message("Could not determine forecast type due to error in validation.")
+  } else {
     cat("Forecast type:\n")
     print(forecast_type)
-  } else {
-    message("Could not determine forecast type due to error in validation.")
   }
 
-  if (!inherits(forecast_unit, "try-error")) {
+  if (inherits(forecast_unit, "try-error")) {
+    message("Could not determine forecast unit due to error in validation.")
+  } else {
     cat("\nForecast unit:\n")
     print(forecast_unit)
-  } else {
-    message("Could not determine forecast unit due to error in validation.")
   }
 
   if (!is.null(score_cols)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -232,10 +232,7 @@ print.forecast_binary <- function(x, ...) {
     do.call(get_forecast_type, list(data = x)),
     silent = TRUE
   )
-  forecast_unit <- try(
-    do.call(get_forecast_unit, list(data = x)),
-    silent = TRUE
-  )
+  forecast_unit <- get_forecast_unit(x)
   score_cols <- get_score_names(x)
 
   # Print forecast object information
@@ -246,8 +243,8 @@ print.forecast_binary <- function(x, ...) {
     print(forecast_type)
   }
 
-  if (inherits(forecast_unit, "try-error")) {
-    message("Could not determine forecast unit due to error in validation.")
+  if (length(forecast_unit) == 0) {
+    message("Could not determine forecast unit")
   } else {
     cat("\nForecast unit:\n")
     print(forecast_unit)

--- a/R/utils.R
+++ b/R/utils.R
@@ -221,11 +221,10 @@ print.forecast_binary <- function(x, ...) {
   validation <- try(do.call(validate_forecast, list(data = x)), silent = TRUE)
   if (inherits(validation, "try-error")) {
     validation_msg <- conditionMessage(attr(validation, "condition"))
-    cat(
-      "The object currently does not pass validation.",
-      "The following error was found:\n"
+    warning(
+      "Error in validating forecast object:\n",
+      validation_msg
     )
-    print(validation_msg)
   }
 
   # get forecast type, forecast unit and score columns
@@ -243,11 +242,15 @@ print.forecast_binary <- function(x, ...) {
   if (!inherits(forecast_type, "try-error")) {
     cat("Forecast type:\n")
     print(forecast_type)
+  } else {
+    message("Could not determine forecast type due to error in validation.")
   }
 
   if (!inherits(forecast_unit, "try-error")) {
     cat("\nForecast unit:\n")
     print(forecast_unit)
+  } else {
+    message("Could not determine forecast unit due to error in validation.")
   }
 
   if (!is.null(score_cols)) {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -140,22 +140,15 @@ test_that("print methods fail gracefully", {
   class(test) <- "forecast_point"
   expect_warning(
     expect_message(
-      expect_output(
-        print(test),
-        pattern = "Forecast unit:"
+      expect_message(
+        expect_output(
+          print(test),
+          pattern = "Forecast unit:"
+        ),
+        "Could not determine forecast unit."
       ),
-      "Could not determine forecast unit."
+      "Could not determine forecast type"
     ),
     "Error in validating forecast object:"
   )
-
-
-
-  if (length(forecast_unit) == 0) {
-    message("Could not determine forecast unit")
-  } else {
-    cat("\nForecast unit:\n")
-    print(forecast_unit)
-  }
-
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -86,10 +86,10 @@ test_that("get_score_names() works as expected", {
 
 test_that("print() works on forecast_* objects", {
   # Check print works on each forecast object
-  test_dat <- list(example_binary, example_quantile,
-    example_point, example_continuous, example_integer)
+  test_dat <- list(na.omit(example_binary), na.omit(example_quantile),
+    na.omit(example_point), na.omit(example_continuous), na.omit(example_integer))
   for (dat in test_dat){
-    dat <- suppressMessages(as_forecast(dat))
+    dat <- as_forecast(dat)
     forecast_type <- get_forecast_type(dat)
     forecast_unit <- get_forecast_unit(dat)
 
@@ -108,11 +108,11 @@ test_that("print() works on forecast_* objects", {
 
   # Check Score columns are printed
   dat <- example_quantile %>%
+    na.omit %>%
     set_forecast_unit(c("location", "target_end_date",
       "target_type", "horizon", "model")) %>%
     as_forecast() %>%
-    add_coverage() %>%
-    suppressMessages
+    add_coverage()
 
   expect_output(print(dat), "Score columns")
   score_cols <- get_score_names(dat)
@@ -123,5 +123,14 @@ test_that("print methods fail gracefully", {
   test <- as_forecast(na.omit(example_quantile))
   test$observed <- NULL
 
-  expect_output(print(test), pattern = "The object currently does not pass validation.")
+  expect_warning(
+    expect_message(
+      expect_output(
+        print(test),
+        pattern = "Forecast unit:"
+      ),
+      "Could not determine forecast type due to error in validation."
+    ),
+    "Error in validating forecast object:"
+  )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -113,3 +113,11 @@ test_that("print() works on forecast_* objects", {
   score_cols <- get_score_names(dat)
   expect_output(print(dat), pattern = paste(score_cols, collapse = " "))
 })
+
+
+test_that("print methods fail gracefully", {
+  test <- as_forecast(na.omit(example_quantile))
+  test$observed <- NULL
+
+  expect_output(print(test), pattern = "The object currently does not pass validation.")
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -79,6 +79,11 @@ test_that("get_score_names() works as expected", {
   )
 })
 
+
+# ==============================================================================
+# print
+# ==============================================================================
+
 test_that("print() works on forecast_* objects", {
   # Check print works on each forecast object
   test_dat <- list(example_binary, example_quantile,
@@ -113,7 +118,6 @@ test_that("print() works on forecast_* objects", {
   score_cols <- get_score_names(dat)
   expect_output(print(dat), pattern = paste(score_cols, collapse = " "))
 })
-
 
 test_that("print methods fail gracefully", {
   test <- as_forecast(na.omit(example_quantile))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -123,6 +123,7 @@ test_that("print methods fail gracefully", {
   test <- as_forecast(na.omit(example_quantile))
   test$observed <- NULL
 
+  # message if forecast type can't be computed
   expect_warning(
     expect_message(
       expect_output(
@@ -133,4 +134,28 @@ test_that("print methods fail gracefully", {
     ),
     "Error in validating forecast object:"
   )
+
+  # message if forecast unit can't be computed
+  test <- 1:10
+  class(test) <- "forecast_point"
+  expect_warning(
+    expect_message(
+      expect_output(
+        print(test),
+        pattern = "Forecast unit:"
+      ),
+      "Could not determine forecast unit."
+    ),
+    "Error in validating forecast object:"
+  )
+
+
+
+  if (length(forecast_unit) == 0) {
+    message("Could not determine forecast unit")
+  } else {
+    cat("\nForecast unit:\n")
+    print(forecast_unit)
+  }
+
 })


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #620 

We recently introduced a print method for forecast objects. This print method was calling `get_forecast_type()` and `get_forecast_unit()` internally which require the object to pass basic validations. If these didn't pass, `print()` would error. 
This PR therefore 
- updates the print method to 
    - run `validate_error()` first and catch any error
    - print any error as part of the output
    - wraps `get_forecast_type()` and `get_forecast_unit()` in `try` statements as well and catches errors
- moves the `score_names` print section to the end. (If we implement #631 then we can likely get rid of that completely, because then no forecast object should have any scores)
- adds a new unit test

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] ~I have updated the documentation if required.~
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] ~I have added a news item linked to this PR.~
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
