### PR TITLE
Issue 643: Fix partial matching

### DIFF
--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -352,7 +352,7 @@ interval_coverage_deviation <- function(observed, predicted, quantile_level) {
   out <- reformatted[, .(
     interval_coverage_deviation = mean(interval_coverage_deviation)
   ), by = "forecast_id"]
-  return(out$interval_coverage_dev)
+  return(out$interval_coverage_deviation)
 }
 
 

--- a/R/utils_data_handling.R
+++ b/R/utils_data_handling.R
@@ -113,7 +113,7 @@ sample_to_quantile <- function(data,
   )
 
   data <- data[, .(quantile_level = quantile_level,
-                   predicted = quantile(x = predicted, prob = ..quantile_level,
+                   predicted = quantile(x = predicted, probs = ..quantile_level,
                                         type = ..type, na.rm = TRUE)),
                by = by]
 

--- a/tests/testthat/test-metrics-point.R
+++ b/tests/testthat/test-metrics-point.R
@@ -64,7 +64,7 @@ test_that("abs error is correct within score, point forecast only", {
   eval <- scoringutils::score(data_scoringutils)
 
   expected <- abs(y - point_forecast)
-  expect_equal(eval$ae, expected)
+  expect_equal(eval$ae_point, expected)
 })
 
 test_that("abs error is correct, point and median forecasts different", {

--- a/tests/testthat/test-utils_data_handling.R
+++ b/tests/testthat/test-utils_data_handling.R
@@ -169,7 +169,7 @@ test_that("quantile_to_range works - scalar and vector case", {
 
   # check error if observed is a vector and predicted is a vector as well
   expect_error(quantile_to_interval(
-    observed = c(1, 2), predicted = c(1, 2), quantile = c(0.1, 0.9)),
+    observed = c(1, 2), predicted = c(1, 2), quantile_level = c(0.1, 0.9)),
     "Assertion on 'predicted' failed: Must be of type 'matrix', not 'double'."
   )
 


### PR DESCRIPTION


<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #643.

[Describe the changes that you made in this pull request.]

Details:
- Fix partial matching of `interval_coverage_dev` to `interval_coverage_deviation`
- Fix partial matching of `prob` to `probs`
- Fix partial matching of `ae` to `ae_point`
- Fix partial matching of `quantile` to `quantil_level`

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.
