### PR TITLE
deleted Assert_equal_length() function

### DIFF
--- a/R/check-input-helpers.R
+++ b/R/check-input-helpers.R
@@ -99,23 +99,6 @@ assert_not_null <- function(...) {
   return(invisible(NULL))
 }
 
-
-#' @title Check Length of Two Vectors is Equal
-#'
-#' @description
-#' Check whether variables all have the same length
-#' @param ... The variables to check
-#' @param one_allowed logical, allow arguments of length one that can be
-#' recycled
-#' @param call_levels_up How many levels to go up when including the function
-#' call in the error message. This is useful when calling `assert_equal_length()`
-#' within another checking function.
-#' @inherit document_assert_functions return
-#'
-#' @keywords internal_input_check
-
-
-
 #' @title Check Whether There Is a Conflict Between Data and Attributes
 #' @description
 #' Check whether there is a conflict between a stored attribute and the

--- a/R/check-input-helpers.R
+++ b/R/check-input-helpers.R
@@ -113,41 +113,7 @@ assert_not_null <- function(...) {
 #' @inherit document_assert_functions return
 #'
 #' @keywords internal_input_check
-assert_equal_length <- function(...,
-                                one_allowed = TRUE,
-                                call_levels_up = 2) {
-  vars <- list(...)
-  lengths <- lengths(vars)
 
-  lengths <- unique(lengths)
-
-  if (one_allowed) {
-    # check passes if all have length 1
-    if (all(lengths == 1)) {
-      return(invisible(NULL))
-    }
-    # ignore those where length is one for later checks, as we allow length 1
-    lengths <- lengths[lengths != 1]
-  }
-
-  if (length(unique(lengths)) != 1) {
-    calling_function <- deparse(sys.calls()[[sys.nframe() - call_levels_up]])
-
-    lengths_message <- ifelse(
-      one_allowed,
-      "' should have the same length (or length one). Actual lengths: ",
-      "' should have the same length. Actual lengths: "
-    )
-
-    stop(
-      "Arguments to the following function call: '",
-      calling_function,
-      lengths_message,
-      toString(lengths)
-    )
-  }
-  return(invisible(NULL))
-}
 
 
 #' @title Check Whether There Is a Conflict Between Data and Attributes


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #645 .

[Describe the changes that you made in this pull request.]
Deleted the function assert_equal_length() function

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] I have built the package locally and run rebuilt docs using roxygen2.
- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
