### PR TITLE
Issue #497: Rename argument `scores` to `coverage` in coverage plot functions

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -508,7 +508,7 @@ make_na <- make_NA
 #' @description
 #' Plot interval coverage
 #'
-#' @param data A data frame of coverage values as produced by
+#' @param coverage A data frame of coverage values as produced by
 #' `get_coverage()`
 #' @param colour According to which variable shall the graphs be coloured?
 #' Default is "model".
@@ -524,10 +524,10 @@ make_na <- make_NA
 #' data_coverage <- add_coverage(example_quantile)
 #' summarised <- summarise_scores(data_coverage, by = c("model", "interval_range"))
 #' plot_interval_coverage(summarised)
-plot_interval_coverage <- function(data,
+plot_interval_coverage <- function(coverage,
                                    colour = "model") {
   ## overall model calibration - empirical interval coverage
-  p1 <- ggplot(data, aes(
+  p1 <- ggplot(coverage, aes(
     x = interval_range,
     colour = .data[[colour]]
   )) +
@@ -577,10 +577,10 @@ plot_interval_coverage <- function(data,
 #' summarised <- summarise_scores(data_coverage, by = c("model", "quantile_level"))
 #' plot_quantile_coverage(summarised)
 
-plot_quantile_coverage <- function(data,
+plot_quantile_coverage <- function(coverage,
                                    colour = "model") {
   p2 <- ggplot(
-    data = data,
+    data = coverage,
     aes(x = quantile_level, colour = .data[[colour]])
   ) +
     geom_polygon(

--- a/man/plot_interval_coverage.Rd
+++ b/man/plot_interval_coverage.Rd
@@ -4,10 +4,10 @@
 \alias{plot_interval_coverage}
 \title{Plot Interval Coverage}
 \usage{
-plot_interval_coverage(data, colour = "model")
+plot_interval_coverage(coverage, colour = "model")
 }
 \arguments{
-\item{data}{A data frame of coverage values as produced by
+\item{coverage}{A data frame of coverage values as produced by
 \code{get_coverage()}}
 
 \item{colour}{According to which variable shall the graphs be coloured?

--- a/man/plot_quantile_coverage.Rd
+++ b/man/plot_quantile_coverage.Rd
@@ -4,10 +4,10 @@
 \alias{plot_quantile_coverage}
 \title{Plot Quantile Coverage}
 \usage{
-plot_quantile_coverage(data, colour = "model")
+plot_quantile_coverage(coverage, colour = "model")
 }
 \arguments{
-\item{data}{A data frame of coverage values as produced by
+\item{coverage}{A data frame of coverage values as produced by
 \code{get_coverage()}}
 
 \item{colour}{According to which variable shall the graphs be coloured?


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #497

The functions were using an argument `scores`. Since the updated workflow doesn't entail obtaining coverage value through `scores`, the argument name should change. 

This PR renames the `scores` argument to `coverage`, in line with other functions such as 
- `plot_forecast_counts` (with an arg `forecast_counts` accepting the output of `get_forecast_counts()`
- `plot_pit` (with an arg `pit` accepting the output of `get_pit()`
- `plot_interval_coverage()` and `plot_quantile_coverage` with arg `coverage` accepting the output of `get_coverage`

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] I have built the package locally and run rebuilt docs using roxygen2.
- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
