### PR TITLE
Fix issue where `plot_interval_coverage()` drops columns

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -292,6 +292,7 @@ plot_interval_coverage <- function(coverage,
   # in case quantile columns are present, remove them and then take unique
   # values. This doesn't visually affect the plot, but prevents lines from being
   # drawn twice.
+  coverage <- ensure_data.table(coverage)
   del <- c("quantile_level", "quantile_coverage", "quantile_coverage_deviation")
   suppressWarnings(coverage[, eval(del) := NULL])
   coverage <- unique(coverage)

--- a/tests/testthat/test-plot_interval_coverage.R
+++ b/tests/testthat/test-plot_interval_coverage.R
@@ -4,4 +4,9 @@ test_that("plot_interval_coverage() works as expected", {
   expect_s3_class(p, "ggplot")
   skip_on_cran()
   suppressWarnings(vdiffr::expect_doppelganger("plot_interval_coverage", p))
+
+  # make sure that plot_interval_coverage() doesn't drop column names
+  expect_true(all(c("interval_coverage", "interval_coverage_deviation",
+                    "quantile_coverage", "quantile_coverage_deviation") %in%
+                  names(coverage)))
 })


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

`plot_interval_coverage()` deletes the `quantile_level` column (and associated coverage values) to avoid plotting duplicated lines (since every interval range appears twice as there are two quantile levels per interval). This PR makes sure that `plot_interval_coverage()` does its thing on a copy of the data. 

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] I have built the package locally and run rebuilt docs using roxygen2.
- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
