### PR TITLE
Issue #640: Update set forecast unit to error if any specified column is not found in the data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ The update introduces breaking changes. If you want to keep using the older vers
 ## Package updates
 - In `score()`, required columns "true_value" and "prediction" were renamed and replaced by required columns "observed" and "predicted". Scoring functions now also use the function arguments "observed" and "predicted" everywhere consistently. 
 - The overall scoring workflow was updated. `score()` is now a generic function that dispatches the correct method based on the forecast type. forecast types currently supported are "binary", "point", "sample" and "quantile" with corresponding classes "forecast_binary", "forecast_point", "forecast_sample" and "forecast_quantile". An object of class `forecast_*` can be created using the function `as_forecast()`, which also replaces the previous function `check_forecasts()` (see more information below). The function also allows users to rename required columns and specify the forecast unit in a single step, taking over the functionality of `set_forecast_unit()` in most cases.
+- `set_forecast_unit()` now errors if any of the values in `forecast_unit` are not columns of the data. 
 - Scoring rules (functions used for scoring) received a consistent interface and input checks:
   - Scoring rules for binary forecasts:
     - `observed`: factor with exactly 2 levels

--- a/R/convenience-functions.R
+++ b/R/convenience-functions.R
@@ -236,7 +236,7 @@ log_shift <- function(x, offset = 0, base = exp(1)) {
 #' )
 set_forecast_unit <- function(data, forecast_unit) {
   data <- ensure_data.table(data)
-  assert_character(forecast_unit, min_len = 1)
+  assert_character(forecast_unit, min.len = 1)
   assert_subset(forecast_unit, names(data))
   keep_cols <- c(get_protected_columns(data), forecast_unit)
   out <- unique(data[, .SD, .SDcols = keep_cols])

--- a/R/convenience-functions.R
+++ b/R/convenience-functions.R
@@ -225,8 +225,8 @@ log_shift <- function(x, offset = 0, base = exp(1)) {
 #' uniquely identify a single forecast.
 #' @return A data.table with only those columns kept that are relevant to
 #' scoring or denote the unit of a single forecast as specified by the user.
-#'
 #' @importFrom data.table ':=' is.data.table copy
+#' @importFrom checkmate assert_character assert_subset
 #' @export
 #' @keywords data-handling
 #' @examples
@@ -236,11 +236,8 @@ log_shift <- function(x, offset = 0, base = exp(1)) {
 #' )
 set_forecast_unit <- function(data, forecast_unit) {
   data <- ensure_data.table(data)
-  missing <- check_columns_present(data, forecast_unit)
-  if (!is.logical(missing)) {
-    warning(missing)
-    forecast_unit <- intersect(forecast_unit, colnames(data))
-  }
+  assert_character(forecast_unit, min_len = 1)
+  assert_subset(forecast_unit, names(data))
   keep_cols <- c(get_protected_columns(data), forecast_unit)
   out <- unique(data[, .SD, .SDcols = keep_cols])
   # validate that output remains a valid forecast object if input was one before

--- a/tests/testthat/test-convenience-functions.R
+++ b/tests/testthat/test-convenience-functions.R
@@ -92,12 +92,13 @@ test_that("set_forecast_unit() revalidates a forecast object", {
 })
 
 
-test_that("function set_forecast_unit() gives warning when column is not there", {
-  expect_warning(
+test_that("function set_forecast_unit() errors when column is not there", {
+  expect_error(
     set_forecast_unit(
       example_quantile,
       c("location", "target_end_date", "target_type", "horizon", "model", "test1", "test2")
-    )
+    ),
+    "Assertion on 'forecast_unit' failed: Must be a subset of "
   )
 })
 


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #640

Currently, `set_forecast_unit()` warns if a column specified in `forecast_unit` is not found in the data, but proceeds nevertheless and ignores offending entries. This may be confusing and an error seems a much clearer option. As discussed in #640, this PR updates the input checks to make sure that the function only executes if all specified columns are actually there. 

The PR also updates tests to reflect that change. 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
