### PR TITLE
reduce number of samples in pit examples

### DIFF
--- a/R/pit.R
+++ b/R/pit.R
@@ -74,8 +74,8 @@
 #' plot_pit(pit)
 #'
 #' ## integer predictions
-#' observed <- rpois(50, lambda = 1:50)
-#' predicted <- replicate(2000, rpois(n = 50, lambda = 1:50))
+#' observed <- rpois(20, lambda = 1:20)
+#' predicted <- replicate(100, rpois(n = 20, lambda = 1:20))
 #' pit <- pit_sample(observed, predicted, n_replicates = 30)
 #' plot_pit(pit)
 #' @export


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

I noticed that the `pit_example()` function uses quite a high number of replications/samples in its example. This PR reduces that. 

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] I have built the package locally and run rebuilt docs using roxygen2.
- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
