### PR TITLE
Issue #672 - Fix `get_correlations()`

### DIFF
--- a/R/correlations.R
+++ b/R/correlations.R
@@ -10,6 +10,7 @@
 #' @param digits A number indicating how many decimal places the result should
 #' be rounded to. By default (`digits = NULL`) no rounding takes place.
 #' @inheritParams get_pairwise_comparisons
+#' @param ... Additional arguments to pass down to [cor()].
 #' @return An object of class `scores` (a data.table with an additional
 #' attribute `metrics` holding the names of the scores) with correlations
 #' between different metrics
@@ -23,20 +24,14 @@
 #' get_correlations(scores, digits = 2)
 get_correlations <- function(scores,
                              metrics = NULL,
-                             digits = NULL) {
+                             digits = NULL,
+                             ...) {
+  scores <- ensure_data.table(scores)
   metrics <- get_metrics(scores, error = TRUE)
-
-  # remove all non metrics and non-numeric columns
-  df <- scores[, .SD, .SDcols = sapply(
-    scores,
-    function(x) {
-      (all(is.numeric(x))) && all(is.finite(x))
-    }
-  )]
-  df <- df[, .SD, .SDcols = names(df) %in% metrics]
+  df <- scores[, .SD, .SDcols = names(scores) %in% metrics]
 
   # define correlation matrix
-  cor_mat <- cor(as.matrix(df))
+  cor_mat <- cor(as.matrix(df), ...)
 
   if (!is.null(digits)) {
     cor_mat <- round(cor_mat, digits)

--- a/man/get_correlations.Rd
+++ b/man/get_correlations.Rd
@@ -4,7 +4,7 @@
 \alias{get_correlations}
 \title{Correlation Between Metrics}
 \usage{
-get_correlations(scores, metrics = NULL, digits = NULL)
+get_correlations(scores, metrics = NULL, digits = NULL, ...)
 }
 \arguments{
 \item{scores}{An object of class \code{scores} (a data.table with
@@ -16,6 +16,8 @@ be shown}
 
 \item{digits}{A number indicating how many decimal places the result should
 be rounded to. By default (\code{digits = NULL}) no rounding takes place.}
+
+\item{...}{Additional arguments to pass down to \code{\link[=cor]{cor()}}.}
 }
 \value{
 An object of class \code{scores} (a data.table with an additional

--- a/tests/testthat/test-get_correlations.R
+++ b/tests/testthat/test-get_correlations.R
@@ -1,0 +1,20 @@
+test_that("get_correlations() works as expected", {
+
+  # expect all to go well in the usual case
+  expect_no_condition(
+    correlations <- scores_quantile %>%
+      summarise_scores(by = get_forecast_unit(scores_quantile)) %>%
+      get_correlations(digits = 2)
+  )
+  expect_equal(
+    colnames(correlations), c(get_metrics(scores_quantile), "metric")
+  )
+
+  # expect no error even if scores are unsummarised
+  # (meaning that coverage will be a logical vecotr instead of a numeric)
+  expect_no_condition(
+    correlations2 <- scores_quantile %>%
+      get_correlations(digits = 2)
+  )
+  expect_equal(correlations, correlations2)
+})


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #672.

I noticed a weird error in #672. The error comes from the fact that if you passed unsummarised scores to `get_correlations()` then it removed the coverage columns because those are not numeric. 

This PR 
- drops the code that does that and lets `cor()` handle any exceptions. 
- adds unit tests with something that would previously have produced an error 
- adds a `...` argument to `get_correlations()`. Not sure how many people will actually want to pass additional args to `cor()` but then again why not... 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
