### PR TITLE
Issue #677 - Warn users if they use an outdated format

### DIFF
--- a/R/forecast.R
+++ b/R/forecast.R
@@ -65,6 +65,7 @@ as_forecast <- function(data,
 #' sample id. This column will be renamed to "sample_id". Only applicable to
 #' sample-based forecasts.
 #' @export
+#' @importFrom cli cli_warn
 as_forecast.default <- function(data,
                                 forecast_unit = NULL,
                                 forecast_type = NULL,
@@ -130,6 +131,41 @@ as_forecast.default <- function(data,
       )
     )
     #nolint end
+  }
+
+  # produce warning if old format is suspected
+  # old quantile format
+  if (forecast_type == "point" && "quantile" %in% colnames(data)) {
+    #nolint start: keyword_quote_linter
+    cli_warn(
+      c(
+        "Found column 'quantile' in the input data",
+        "i" = "This column name was used before scoringutils version 2.0.0.
+        Should the column be called 'quantile_level' instead?"
+      ),
+      .frequency = "once",
+      .frequency_id = "quantile_col_present"
+    )
+    #nolint end
+  }
+  #old binary format
+  if (forecast_type == "point") {
+    looks_binary <- check_input_binary(factor(data$observed), data$predicted)
+    if (is.logical(looks_binary)) {
+      #nolint start: keyword_quote_linter duplicate_argument_linter
+      cli_warn(
+        c(
+          "All observations are either 1 or 0.",
+          "i" = "The forecast type was classified as 'point', but it looks like
+          it could be a binary forecast as well.",
+          "i" = "In case you want it to be a binary forecast, convert `observed`
+          to a factor. See `?as_forecast()` for more information."
+        ),
+        .frequency = "once",
+        .frequency_id = "looks_binary"
+      )
+      #nolint end
+    }
   }
 
   # construct class

--- a/tests/testthat/test-forecast.R
+++ b/tests/testthat/test-forecast.R
@@ -173,6 +173,35 @@ test_that("output of as_forecasts() is accepted as input to score()", {
   expect_equal(score_check, suppressMessages(score(as_forecast(example_binary))))
 })
 
+
+test_that("as_forecast() produces a warning if outdated formats are used", {
+  test_data <- data.frame(
+    observed = rep(c(1, -15, 22), times = 2),
+    quantile = rep(c(0.25, 0.75), each = 3),
+    predicted = c(c(0, 1, 0), c(2, 2, 3)),
+    model = c("model1"),
+    date = rep(1:3, times = 2)
+  )
+
+  expect_warning(
+    as_forecast(test_data),
+    "Found column 'quantile' in the input data",
+  )
+
+  test_data2 <- data.frame(
+    observed = c(1, 0, 0, 1, 0, 1),
+    predicted = c(0.2, 0.4, 0.1, 0.8, 0.1, 0.3),
+    model = c("model1", "model2"),
+    date = rep(1:3, times = 2)
+  )
+
+  expect_warning(
+    as_forecast(test_data2),
+    "The forecast type was classified as 'point', but it looks like"
+  )
+})
+
+
 # ==============================================================================
 # is_forecast()
 # ==============================================================================


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #677.
This PR closes #603.

The change to the new format may be somewhat confusing for users in a few particular circumstances. For example, if you have a `quantile` column instead of a `quantile_level` column then `scoringutils` now thinks this is just any normal column and classifies your forecast as a point forecast. Or if you want to score a binary forecast, but forget to make your observed values a factor, then you'll end up with a point forecast again. 

This PR
- adds once-per-session warnings for both of these things
- adds tests to check that

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
