### PR TITLE
Issue #245 - add additional input checks to `plot_correlations()`

### DIFF
--- a/tests/testthat/test-plot_correlation.R
+++ b/tests/testthat/test-plot_correlation.R
@@ -10,4 +10,10 @@ test_that("plot_correlations() works as expected", {
   expect_s3_class(p, "ggplot")
   skip_on_cran()
   vdiffr::expect_doppelganger("plot__correlation", p)
+
+  # expect an error if you forgot to compute correlations
+  expect_error(
+    plot_correlations(summarise_scores(scores_quantile)),
+    "Did you forget to call `scoringutils::get_correlations()`?"
+  )
 })


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #245. 

#245 notes that you don't get a very informative error message if you pass something that's not the output of `get_correlations()` to `plot_correlations()`. 

This PR
- adds additional input checks to make sure that
  - the input is a data.frame
  - there is a `metric` column and all correlations are <= 1
- adds a test

I assume there would be potential to make all of this more sophisticated, but I think for now it should do the trick. 

[Describe the changes that you made in this pull request.]

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
