### PR TITLE
Issue #355 - Add input checks to `plot_heatmap`

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -231,10 +231,15 @@ plot_wis <- function(scores,
 #' @importFrom data.table setDT `:=`
 #' @importFrom ggplot2 ggplot  aes geom_tile geom_text .data
 #' scale_fill_gradient2 labs element_text coord_cartesian
+#' @importFrom checkmate assert_subset
 #' @export
 #' @examples
 #' scores <- score(as_forecast(example_quantile))
 #' scores <- summarise_scores(scores, by = c("model", "target_type"))
+#' scores <- summarise_scores(
+#'   scores, by = c("model", "target_type"),
+#'   fun = signif, digits = 2
+#' )
 #'
 #' plot_heatmap(scores, x = "target_type", metric = "bias")
 
@@ -242,9 +247,10 @@ plot_heatmap <- function(scores,
                          y = "model",
                          x,
                          metric) {
-  data.table::setDT(scores)
-
-  scores[, eval(metric) := round(get(metric), 2)]
+  scores <- ensure_data.table(scores)
+  assert_subset(y, names(scores))
+  assert_subset(x, names(scores))
+  assert_subset(metric, names(scores))
 
   plot <- ggplot(
     scores,

--- a/man/plot_heatmap.Rd
+++ b/man/plot_heatmap.Rd
@@ -30,6 +30,10 @@ different locations.
 \examples{
 scores <- score(as_forecast(example_quantile))
 scores <- summarise_scores(scores, by = c("model", "target_type"))
+scores <- summarise_scores(
+  scores, by = c("model", "target_type"),
+  fun = signif, digits = 2
+)
 
 plot_heatmap(scores, x = "target_type", metric = "bias")
 }

--- a/tests/testthat/test-plot_heatmap.R
+++ b/tests/testthat/test-plot_heatmap.R
@@ -1,7 +1,9 @@
 library(ggplot2, quietly = TRUE)
 
 test_that("plot_heatmap() works as expected", {
-  scores <- summarise_scores(scores_quantile, by = c("model", "target_type"))
+  scores <- scores_quantile %>%
+    summarise_scores(by = c("model", "target_type")) %>%
+    summarise_scores(by = c("model", "target_type"), fun = round, digits = 2)
   p <- plot_heatmap(scores, x = "target_type", metric = "bias")
   expect_s3_class(p, "ggplot")
   skip_on_cran()


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

Cleaning up plotting functions. 

This PR
- adds input checks to `plot_heatmap()`
- removes the forced `round()` statement in the code and instead makes the user responsible for rounding. I really think it is these small breaking changes that users will love us for... One alternative would have been an additional `digits` argument (we do that for `get_correlations()`, but not for `plot_correlations()` for example). 

Another slightly more radical step would be to remove the function altogether and replace it with a vignette entry. I'm not really sure the function adds that much over "you go ahead and write your `ggplot` code and here is an example for how you could do that if you wanted". What do you think? 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] ~I have added a news item linked to this PR.~
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
