### PR TITLE
Replace `by = NULL` with `by = get_forecast_unit(data)` in `get_forecast_counts()`

### DIFF
--- a/R/get_-functions.R
+++ b/R/get_-functions.R
@@ -397,7 +397,7 @@ get_coverage <- function(data, by = "model") {
 #'
 #' @param by character vector or `NULL` (the default) that denotes the
 #' categories over which the number of forecasts should be counted.
-#' By default (`by = NULL`) this will be the unit of a single forecast (i.e.
+#' By default this will be the unit of a single forecast (i.e.
 #' all available columns (apart from a few "protected" columns such as
 #' 'predicted' and 'observed') plus "quantile_level" or "sample_id" where
 #' present).
@@ -427,16 +427,13 @@ get_coverage <- function(data, by = "model") {
 #'   by = c("model", "target_type")
 #' )
 get_forecast_counts <- function(data,
-                                by = NULL,
+                                by = get_forecast_unit(data),
                                 collapse = c("quantile_level", "sample_id")) {
   data <- copy(data)
   suppressWarnings(suppressMessages(validate_forecast(data)))
   forecast_unit <- get_forecast_unit(data)
   data <- na.omit(data)
-
-  if (is.null(by)) {
-    by <- forecast_unit
-  }
+  assert_subset(by, names(data))
 
   # collapse several rows to 1, e.g. treat a set of 10 quantiles as one,
   # because they all belong to one single forecast that should be counted once

--- a/man/get_forecast_counts.Rd
+++ b/man/get_forecast_counts.Rd
@@ -6,7 +6,7 @@
 \usage{
 get_forecast_counts(
   data,
-  by = NULL,
+  by = get_forecast_unit(data),
   collapse = c("quantile_level", "sample_id")
 )
 }
@@ -16,7 +16,7 @@ observed values, see \code{\link[=as_forecast]{as_forecast()}})}
 
 \item{by}{character vector or \code{NULL} (the default) that denotes the
 categories over which the number of forecasts should be counted.
-By default (\code{by = NULL}) this will be the unit of a single forecast (i.e.
+By default this will be the unit of a single forecast (i.e.
 all available columns (apart from a few "protected" columns such as
 'predicted' and 'observed') plus "quantile_level" or "sample_id" where
 present).}


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

We started replacing `by = NULL` with `by = get_forecast_unit(data)` to increase clarity for users. This PR cleans up the last place where this is not the case yet and updates the docs. 

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
