### PR TITLE
Issue #744 - Fix weird .internal.selfref error by making a copy in `check_number_per_forecast()`

### DIFF
--- a/R/check-input-helpers.R
+++ b/R/check-input-helpers.R
@@ -119,7 +119,6 @@ ensure_model_column <- function(data) {
 check_number_per_forecast <- function(data, forecast_unit) {
   data <- ensure_data.table(data)
   data <- na.omit(data)
-  assert_subset(forecast_unit, colnames(data))
   # check whether there are the same number of quantiles, samples --------------
   data[, scoringutils_InternalNumCheck := length(predicted), by = forecast_unit]
   n <- unique(data$scoringutils_InternalNumCheck)

--- a/R/check-input-helpers.R
+++ b/R/check-input-helpers.R
@@ -113,11 +113,13 @@ ensure_model_column <- function(data) {
 #' If the number of quantiles or samples is the same for all forecasts, it
 #' returns TRUE and a string with an error message otherwise.
 #' @param forecast_unit Character vector denoting the unit of a single forecast.
+#' @importFrom checkmate assert_subset
 #' @inherit document_check_functions params return
 #' @keywords internal_input_check
 check_number_per_forecast <- function(data, forecast_unit) {
   data <- ensure_data.table(data)
   data <- na.omit(data)
+  assert_subset(forecast_unit, colnames(data))
   # check whether there are the same number of quantiles, samples --------------
   data[, scoringutils_InternalNumCheck := length(predicted), by = forecast_unit]
   n <- unique(data$scoringutils_InternalNumCheck)

--- a/R/check-input-helpers.R
+++ b/R/check-input-helpers.R
@@ -116,6 +116,7 @@ ensure_model_column <- function(data) {
 #' @inherit document_check_functions params return
 #' @keywords internal_input_check
 check_number_per_forecast <- function(data, forecast_unit) {
+  data <- ensure_data.table(data)
   data <- na.omit(data)
   # check whether there are the same number of quantiles, samples --------------
   data[, scoringutils_InternalNumCheck := length(predicted), by = forecast_unit]


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #744.

From #744: 

> I found a very weird error when analysing some data: 

```
Invalid .internal.selfref detected and fixed by taking a (shallow) copy of the data.table so that := can add this new column by reference. At an earlier point, this data.table has been copied by R (or was created manually using structure() or similar). Avoid names<- and attr<- which in R currently (and oddly) may copy the whole data.table. Use set* syntax instead to avoid copying: ?set, ?setnames and ?setattr. If this message doesn't help, please report your use case to the data.table issue tracker so the root cause can be fixed or this message improved. ” 
```

> This has something to do with a mix of `dplyr` and `data.table` and occurred when I called `mutate()` on a forecast object. I was analysing some private data and therefore don't have a reprex (I failed to reproduce the error given the package example data). But the error seems to be due to `check_number_per_forecast()` (illustrating again what I hero I am when it comes to naming functions...). The function makes changes to the input without making a copy first. 

This PR fixes the error by adding an `ensure_data.table()` statement to `check_number_per_forecast()` in which the input gets copied once. That causes some overhead, but it fixes the error 🤷 . 

I briefly thought about adding an input check for the `forecast_unit` argument. But then I remembered that I am a good boi and don't do unrelated changes and reverted it. 
Maybe worth having a general discussion about whether or not we want input checks for internal functions? On the one hand they don't seem strictly necessary as we can control their use, but then again it doesn't cause much overhead. 

<img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRRX-ve28_I4tpg0SYablNe6OkvVVdp1M6QSk9O1UHRBQ&s" width=400>

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
