### PR TITLE
Issue #447 - Add even more input checks

### DIFF
--- a/R/get_-functions.R
+++ b/R/get_-functions.R
@@ -190,7 +190,7 @@ get_metrics <- function(scores, error = FALSE) {
     #nolint start: keyword_quote_linter
     cli_abort(
       c(
-        "!" = "Object needs an attribute `metrics` with the names of the
+        "!" = "Input needs an attribute `metrics` with the names of the
          scoring rules that were used for scoring.",
         "i" = "See `?get_metrics` for further information."
       )

--- a/R/summarise_scores.R
+++ b/R/summarise_scores.R
@@ -53,6 +53,7 @@
 #'   summarise_scores(fun = signif, digits = 2)
 #' @export
 #' @importFrom checkmate assert_subset assert_function test_subset
+#'   assert_data_frame
 #' @keywords scoring
 
 summarise_scores <- function(scores,
@@ -61,26 +62,13 @@ summarise_scores <- function(scores,
                              fun = mean,
                              ...) {
   # input checking ------------------------------------------------------------
-  # Check the score names attribute exists
-  metrics <- attr(scores, "metrics")
-  if (is.null(metrics)) {
-    stop("`scores` needs to have an attribute `metrics` with ",
-         "the names of the metrics that were used for scoring.")
-  }
-
-  if (!test_subset(metrics, names(scores))) {
-    warning(
-      "The names of the scores previously computed do not match the names ",
-      "of the columns in `scores`. This may lead to unexpected results."
-    )
-  }
-
-  # get the forecast unit (which relies on the presence of a scores attribute)
-  forecast_unit <- get_forecast_unit(scores)
-
+  assert_data_frame(scores)
   assert_subset(by, names(scores), empty.ok = TRUE)
   assert_subset(across, names(scores), empty.ok = TRUE)
   assert_function(fun)
+  metrics <- get_metrics(scores, error = TRUE)
+
+  forecast_unit <- get_forecast_unit(scores)
 
   # if across is provided, calculate new `by`
   if (!is.null(across)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,6 +14,7 @@
 #' @param ... Arguments to pass to `fun`.
 #' @param fun A function to execute.
 #' @importFrom cli cli_warn
+#' @importFrom checkmate assert_function
 #' @return The result of `fun` or `NULL` if `fun` errors
 #' @export
 #' @keywords scoring
@@ -24,6 +25,7 @@
 #' run_safely(fun = f)
 #' run_safely(y = 3, fun = f)
 run_safely <- function(..., fun) {
+  assert_function(fun)
   args <- list(...)
   # Check if the function accepts ... as an argument
   if ("..." %in% names(formals(fun))) {

--- a/R/utils_data_handling.R
+++ b/R/utils_data_handling.R
@@ -17,6 +17,7 @@
 #' @param by Character vector that denotes the columns by which to merge. Any
 #'   value that is not a column in observations will be removed.
 #' @return a data.table with forecasts and observations
+#' @importFrom checkmate assert_subset
 #' @examples
 #' forecasts <- example_quantile_forecasts_only
 #' observations <- example_truth_only
@@ -27,8 +28,10 @@
 merge_pred_and_obs <- function(forecasts, observations,
                                join = c("left", "full", "right"),
                                by = NULL) {
-  forecasts <- data.table::as.data.table(forecasts)
-  observations <- data.table::as.data.table(observations)
+  forecasts <- ensure_data.table(forecasts)
+  observations <- ensure_data.table(observations)
+  join <- match.arg(join)
+  assert_subset(by, intersect(names(forecasts), names(observations)))
 
   if (is.null(by)) {
     protected_columns <- c(

--- a/R/utils_data_handling.R
+++ b/R/utils_data_handling.R
@@ -97,6 +97,7 @@ merge_pred_and_obs <- function(forecasts, observations,
 #' @importFrom data.table as.data.table
 #' @importFrom stats quantile
 #' @importFrom methods hasArg
+#' @importFrom checkmate assert_numeric
 #' @keywords data-handling
 #' @export
 #' @examples
@@ -105,6 +106,7 @@ sample_to_quantile <- function(data,
                                quantile_level = c(0.05, 0.25, 0.5, 0.75, 0.95),
                                type = 7) {
   data <- ensure_data.table(data)
+  assert_numeric(quantile_level, min.len = 1)
   reserved_columns <- c("predicted", "sample_id")
   by <- setdiff(colnames(data), reserved_columns)
 
@@ -135,11 +137,10 @@ sample_to_quantile <- function(data,
 #' @param keep_range_col Logical, default is `FALSE`. Keep the
 #'   interval_range and boundary columns after transformation?
 #' @return a data.table in a plain quantile format
-#' @importFrom data.table copy
 #' @keywords internal
 interval_long_to_quantile <- function(data,
                                       keep_range_col = FALSE) {
-  data <- data.table::as.data.table(data)
+  data <- ensure_data.table(data)
 
   # filter out duplicated median
   # note that this also filters out instances where range is NA, i.e.
@@ -290,7 +291,7 @@ sample_to_interval_long <- function(data,
                                     interval_range = c(0, 50, 90),
                                     type = 7,
                                     keep_quantile_col = TRUE) {
-  data <- data.table::as.data.table(data)
+  data <- ensure_data.table(data)
 
   lower_quantiles <- (100 - interval_range) / 200
   upper_quantiles <- 1 - lower_quantiles

--- a/tests/testthat/test-summarise_scores.R
+++ b/tests/testthat/test-summarise_scores.R
@@ -37,7 +37,7 @@ test_that("summarise_scores() handles the `metrics` attribute correctly", {
 
   expect_error(
     summarise_scores(test, by = "model"),
-    "`scores` needs to have an attribute `metrics` with the names"
+    "Input needs an attribute `metrics` with the names"
   )
 
   # expect warning if a score name changed

--- a/tests/testthat/test-summarise_scores.R
+++ b/tests/testthat/test-summarise_scores.R
@@ -45,7 +45,7 @@ test_that("summarise_scores() handles the `metrics` attribute correctly", {
   data.table::setnames(test, old = "crps", new = "crp2")
   expect_warning(
     summarise_scores(test, by = "model"),
-    "The names of the scores previously computed do not match the names"
+    "The following scores have been previously computed, but are no longer"
   )
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -64,7 +64,7 @@ test_that("get_metrics() works as expected", {
   #check that function errors if `error = TRUE` and not otherwise
   expect_error(
     get_metrics(example_quantile, error = TRUE),
-    "Object needs an attribute"
+    "Input needs an attribute"
   )
   expect_no_condition(
     get_metrics(scores_continuous)


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

As discussed in #447, some functions lack input checks. This is the third PR that adds more checks. 

This PR
- simplifies input checks in `summarise_scores()`
- slightly updates the error message in `get_metrics()` + associated tests
- adds input checks to 
  - `merge_pred_and_obs()`
  - `sample_to_quantile()`
  - `run_safely()`
- replaces some `data.table::` calls with `ensure_data.table()`

**Further thoughts**: 
- there is an argument to be made that `sample_to_quantile()` should require a validated `forecast_sample`. I opened a separate issue for this: https://github.com/epiforecasts/scoringutils/issues/755
-  

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
