### PR TITLE
Fix small typo in the readme

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -104,7 +104,7 @@ forecast_quantile <- example_quantile |>
     forecast_type = "quantile"
   )
 
-head(forecast_quantile, 2)
+print(forecast_quantile, 2)
 ```
 
 ### The forecast unit

--- a/README.Rmd
+++ b/README.Rmd
@@ -55,7 +55,7 @@ cat("\n\n")
 
 The `scoringutils` package facilitates the process of evaluating forecasts in R, using a convenient and flexible `data.table`-based framework. It provides broad functionality to check the input data and diagnose issues, to visualise forecasts and missing data, to transform data before scoring, to handle missing forecasts, to aggregate scores, and to visualise the results of the evaluation. The package is easily extendable, meaning that users can supply their own scoring rules or extend existing classes to handle new types of forecasts. 
 
-The package underwent a major re-write. The most comprehensive documentation for the [updated version](https://drive.google.com/file/d/1URaMsXmHJ1twpLpMl1sl2HW4lPuUycoj/view?usp=drive_link) is the revised version of our [original](https://doi.org/10.48550/arXiv.2205.07090) `scoringutils` paper. 
+The package underwent a major re-write. The most comprehensive documentation for the updated package is the [revised version](https://drive.google.com/file/d/1URaMsXmHJ1twpLpMl1sl2HW4lPuUycoj/view?usp=drive_link) of our [original](https://doi.org/10.48550/arXiv.2205.07090) `scoringutils` paper. 
 
 Another good starting point are the vignettes on [Getting started](https://epiforecasts.io/scoringutils/articles/scoringutils.html), [Details on the metrics implemented](https://epiforecasts.io/scoringutils/articles/metric-details.html) and [Scoring forecasts directly](https://epiforecasts.io/scoringutils/articles/scoring-forecasts-directly.html).
 

--- a/README.md
+++ b/README.md
@@ -104,23 +104,32 @@ forecast_quantile <- example_quantile |>
 #> ℹ Some rows containing NA values may be removed. This is fine if not
 #>   unexpected.
 
-head(forecast_quantile, 2)
-#> Warning: ! Error in validating forecast object: Error in validate_general(data) : !
-#>   After removing rows with NA values in the data, no forecasts are left. .
+print(forecast_quantile, 2)
+#> ℹ Some rows containing NA values may be removed. This is fine if not
+#>   unexpected.
 #> Forecast type:
+#> 
 #> quantile
+#> 
 #> Forecast unit:
+#> 
 #> location, forecast_date, target_end_date, target_type, model, and horizon
 #> 
 #> Key: <location, target_end_date, target_type>
-#>    observed quantile_level predicted location forecast_date target_end_date
-#>       <num>          <num>     <int>   <char>        <Date>          <Date>
-#> 1:   127300             NA        NA       DE          <NA>      2021-01-02
-#> 2:     4534             NA        NA       DE          <NA>      2021-01-02
-#>    target_type  model horizon
-#>         <char> <char>   <num>
-#> 1:       Cases   <NA>      NA
-#> 2:      Deaths   <NA>      NA
+#>        observed quantile_level predicted location forecast_date target_end_date
+#>           <num>          <num>     <int>   <char>        <Date>          <Date>
+#>     1:   127300             NA        NA       DE          <NA>      2021-01-02
+#>     2:     4534             NA        NA       DE          <NA>      2021-01-02
+#>    ---                                                                         
+#> 20544:       78          0.975       611       IT    2021-07-12      2021-07-24
+#> 20545:       78          0.990       719       IT    2021-07-12      2021-07-24
+#>        target_type                model horizon
+#>             <char>               <char>   <num>
+#>     1:       Cases                 <NA>      NA
+#>     2:      Deaths                 <NA>      NA
+#>    ---                                         
+#> 20544:      Deaths epiforecasts-EpiNow2       2
+#> 20545:      Deaths epiforecasts-EpiNow2       2
 ```
 
 ### The forecast unit

--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ extendable, meaning that users can supply their own scoring rules or
 extend existing classes to handle new types of forecasts.
 
 The package underwent a major re-write. The most comprehensive
-documentation for the [updated
+documentation for the updated package is the [revised
 version](https://drive.google.com/file/d/1URaMsXmHJ1twpLpMl1sl2HW4lPuUycoj/view?usp=drive_link)
-is the revised version of our
-[original](https://doi.org/10.48550/arXiv.2205.07090) `scoringutils`
-paper.
+of our [original](https://doi.org/10.48550/arXiv.2205.07090)
+`scoringutils` paper.
 
 Another good starting point are the vignettes on [Getting
 started](https://epiforecasts.io/scoringutils/articles/scoringutils.html),


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR fixes two small issues in the Readme: 
- The readme currently uses `head(data, 2)` to print the first two rows of a forecast object. This means that the forecast object fails validation (as it only has two rows with `NA` values left. This PR changes `head(data, 2)` to `print(data, 2)` which solves the problem. 
- The link to the revised paper should belong to "revised version" not "updated version". I slightly adapted the link. 

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] I have built the package locally and run rebuilt docs using roxygen2.
- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
