### PR TITLE
Issue #761 - Update input checks and docs for `quantile_score()`

### DIFF
--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -594,6 +594,35 @@ ae_median_quantile <- function(observed, predicted, quantile_level) {
 #' The quantile score is closely related to the interval score (see [wis()]) and
 #' is the quantile equivalent that works with single quantiles instead of
 #' central prediction intervals.
+#'
+#' The quantile score, also called pinball loss, for a single quantile
+#' level \eqn{\tau} is defined as
+#' \deqn{
+#'   \text{QS}_\tau(F, y) = 2 \cdot \{ \mathbf{1}(y \leq q_\tau) - \tau\} \cdot (q_\tau − y) =
+#'   \begin{cases}
+#' 2 \cdot (1 - \tau) * q_\tau - y,       & \text{if } y \leq q_\tau\\
+#' 2 \cdot \tau * |q_\tau - y|,           & \text{if } y > q_\tau,
+#' \end{cases}
+#' }
+#' with \eqn{q_\tau} being the \eqn{\tau}-quantile of the predictive
+#' distribution \eqn{F}, and \eqn{\mathbf{1}(\cdot)} the indicator function.
+#'
+#' The weighted interval score for a single prediction interval can be obtained
+#' as the average of the quantile scores for the lower and upper quantile of
+#' that prediction interval:
+#' \deqn{
+#'   \text{WIS}_\alpha(F, y) = \frac{\text{QS}_{\alpha/2}(F, y)
+#'   + \text{QS}_{1 - \alpha/2}(F, y)}{2}.
+#' }
+#' See the SI of Bracher et al. (2021) for more details.
+#'
+#' `quantile_score()` returns the average quantile score across the quantile
+#' levels provided. For a set of quantile levels that form pairwise central
+#' prediction intervals, the quantile score is equivalent to the interval score.
+#' @return Numeric vector of length n with the quantile score. The scores are
+#' averaged across quantile levels if multiple quantile levels are provided
+#' (the result of calling `rowMeans()` on the matrix of quantile scores that
+#' is computed based on the observed and predicted values).
 #' @inheritParams wis
 #' @examples
 #' observed <- rnorm(10, mean = 1:10)
@@ -630,7 +659,7 @@ ae_median_quantile <- function(observed, predicted, quantile_level) {
 #' Statistical Association, Volume 102, 2007 - Issue 477
 #'
 #' Evaluating epidemic forecasts in an interval format,
-#' Johannes Bracher, Evan L. Ray, Tilmann Gneiting and Nicholas G. Reich,
+#' Johannes Bracher, Evan L. Ray, Tilmann Gneiting and Nicholas G. Reich, 2021,
 #' <https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1008618>
 quantile_score <- function(observed,
                            predicted,

--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -611,6 +611,13 @@ ae_median_quantile <- function(observed, predicted, quantile_level) {
 #'   quantile_level = 1 - alpha / 2
 #' )
 #' interval_score <- (qs_lower + qs_upper) / 2
+#'
+#' # this is the same as the following
+#' wis(
+#'   observed,
+#'   predicted = cbind(lower, upper),
+#'   quantile_level = c(alpha / 2, 1 - alpha / 2)
+#' )
 #' @export
 #' @keywords metric
 #' @references Strictly Proper Scoring Rules, Prediction,and Estimation,

--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -628,8 +628,8 @@ ae_median_quantile <- function(observed, predicted, quantile_level) {
 #' observed <- rnorm(10, mean = 1:10)
 #' alpha <- 0.5
 #'
-#' lower <- qnorm(alpha / 2, rnorm(10, mean = 1:10))
-#' upper <- qnorm((1 - alpha / 2), rnorm(10, mean = 1:10))
+#' lower <- qnorm(alpha / 2, observed)
+#' upper <- qnorm((1 - alpha / 2), observed)
 #'
 #' qs_lower <- quantile_score(observed,
 #'   predicted = matrix(lower),

--- a/man/quantile_score.Rd
+++ b/man/quantile_score.Rd
@@ -69,8 +69,8 @@ prediction intervals, the quantile score is equivalent to the interval score.
 observed <- rnorm(10, mean = 1:10)
 alpha <- 0.5
 
-lower <- qnorm(alpha / 2, rnorm(10, mean = 1:10))
-upper <- qnorm((1 - alpha / 2), rnorm(10, mean = 1:10))
+lower <- qnorm(alpha / 2, observed)
+upper <- qnorm((1 - alpha / 2), observed)
 
 qs_lower <- quantile_score(observed,
   predicted = matrix(lower),

--- a/man/quantile_score.Rd
+++ b/man/quantile_score.Rd
@@ -28,11 +28,42 @@ to the CRPS. \eqn{\alpha} is the value that corresponds to the
 value that represents how much is outside a central prediction interval
 (E.g. for a 90 percent central prediction interval, alpha is 0.1).}
 }
+\value{
+Numeric vector of length n with the quantile score. The scores are
+averaged across quantile levels if multiple quantile levels are provided
+(the result of calling \code{rowMeans()} on the matrix of quantile scores that
+is computed based on the observed and predicted values).
+}
 \description{
 Proper Scoring Rule to score quantile predictions. Smaller values are better.
 The quantile score is closely related to the interval score (see \code{\link[=wis]{wis()}}) and
 is the quantile equivalent that works with single quantiles instead of
 central prediction intervals.
+
+The quantile score, also called pinball loss, for a single quantile
+level \eqn{\tau} is defined as
+\deqn{
+  \text{QS}_\tau(F, y) = 2 \cdot \{ \mathbf{1}(y \leq q_\tau) - \tau\} \cdot (q_\tau − y) =
+  \begin{cases}
+2 \cdot (1 - \tau) * q_\tau - y,       & \text{if } y \leq q_\tau\\
+2 \cdot \tau * |q_\tau - y|,           & \text{if } y > q_\tau,
+\end{cases}
+}
+with \eqn{q_\tau} being the \eqn{\tau}-quantile of the predictive
+distribution \eqn{F}, and \eqn{\mathbf{1}(\cdot)} the indicator function.
+
+The weighted interval score for a single prediction interval can be obtained
+as the average of the quantile scores for the lower and upper quantile of
+that prediction interval:
+\deqn{
+  \text{WIS}_\alpha(F, y) = \frac{\text{QS}_{\alpha/2}(F, y)
+  + \text{QS}_{1 - \alpha/2}(F, y)}{2}.
+}
+See the SI of Bracher et al. (2021) for more details.
+
+\code{quantile_score()} returns the average quantile score across the quantile
+levels provided. For a set of quantile levels that form pairwise central
+prediction intervals, the quantile score is equivalent to the interval score.
 }
 \examples{
 observed <- rnorm(10, mean = 1:10)
@@ -69,7 +100,7 @@ Tilmann Gneiting and Adrian E. Raftery, 2007, Journal of the American
 Statistical Association, Volume 102, 2007 - Issue 477
 
 Evaluating epidemic forecasts in an interval format,
-Johannes Bracher, Evan L. Ray, Tilmann Gneiting and Nicholas G. Reich,
+Johannes Bracher, Evan L. Ray, Tilmann Gneiting and Nicholas G. Reich, 2021,
 \url{https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1008618}
 }
 \keyword{metric}

--- a/man/quantile_score.Rd
+++ b/man/quantile_score.Rd
@@ -42,14 +42,26 @@ lower <- qnorm(alpha / 2, rnorm(10, mean = 1:10))
 upper <- qnorm((1 - alpha / 2), rnorm(10, mean = 1:10))
 
 qs_lower <- quantile_score(observed,
-  predicted = lower,
+  predicted = matrix(lower),
   quantile_level = alpha / 2
 )
 qs_upper <- quantile_score(observed,
-  predicted = upper,
+  predicted = matrix(upper),
   quantile_level = 1 - alpha / 2
 )
 interval_score <- (qs_lower + qs_upper) / 2
+interval_score2 <- quantile_score(
+  observed,
+  predicted = cbind(lower, upper),
+  quantile_level = c(alpha / 2, 1 - alpha / 2)
+)
+
+# this is the same as the following
+wis(
+  observed,
+  predicted = cbind(lower, upper),
+  quantile_level = c(alpha / 2, 1 - alpha / 2)
+)
 }
 \references{
 Strictly Proper Scoring Rules, Prediction,and Estimation,

--- a/tests/testthat/test-metrics-quantile.R
+++ b/tests/testthat/test-metrics-quantile.R
@@ -503,12 +503,12 @@ test_that("Quantlie score and interval score yield the same result, weigh = FALS
     )
 
     qs_lower <- quantile_score(observed,
-                               predicted = lower,
+                               predicted = matrix(lower),
                                quantile_level = alpha / 2,
                                weigh = w
     )
     qs_upper <- quantile_score(observed,
-                               predicted = upper,
+                               predicted = matrix(upper),
                                quantile_level = 1 - alpha / 2,
                                weigh = w
     )
@@ -547,12 +547,12 @@ test_that("Quantlie score and interval score yield the same result, weigh = TRUE
     )
 
     qs_lower <- quantile_score(observed,
-                               predicted = lower,
+                               predicted = matrix(lower),
                                quantile_level = alpha / 2,
                                weigh = w
     )
     qs_upper <- quantile_score(observed,
-                               predicted = upper,
+                               predicted = matrix(upper),
                                quantile_level = 1 - alpha / 2,
                                weigh = w
     )

--- a/tests/testthat/test-metrics-quantile.R
+++ b/tests/testthat/test-metrics-quantile.R
@@ -478,6 +478,14 @@ test_that("wis is correct, 2 intervals and median - test corresponds to covidHub
 })
 
 test_that("Quantlie score and interval score yield the same result, weigh = FALSE", {
+
+  # calling quantile_score and wis should return the same result if all
+  # quantiles form central prediction intervals
+  expect_equal(
+    quantile_score(observed, predicted, quantile_level),
+    wis(observed, predicted, quantile_level)
+  )
+
   observed <- rnorm(10, mean = 1:10)
   alphas <- c(0.1, 0.5, 0.9)
 


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #761.

Previously, the function `quantile_score()` inherited its arguments from `wis()`, but the actual format it expected was different from the one used by the other quantile-based metrics. 
The function used to expect a vector of observed values and a single vector with predicted values and a single quantile level. This is in contrast to the other quantile-based functions, which usually expect a matrix of predicted values and are also able to accept several quantile levels. 

This PR changes the expected input format of `quantile_score()` such that it conforms to what the other functions accept. Instead of computing the quantile score for a single vector, it now computes the score for several quantile forecasts and returns an average score. One implication of this is that the output of `wis()` and `quantile_score()` are now mostly identical, apart from the fact that 
- `wis()` can only compute something if two quantiles form a prediction interval
- `quantile_score()` can compute a score for a single quantile level, but doesn't offer the decomposition

The PR
- adds new input checks to `quantile_score()`
- rewrites the code to work with matrices instead of vectors
- taught me about the existence of the `sweep()` function (admittedly I'm still not entirely sure what it does). `R` magic of the ancients, forged before the time of man. 
- adds a new unit test to test the new behaviour
- updates the documentation


I haven't added a news item because the update is changing the input formats for all functions (we just hadn't properly implemented that change for `quantile_score()` yet)

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
