### PR TITLE
Issue #693 - Remove `forecast_unit` argument from `get_duplicate_forecasts()`

### DIFF
--- a/R/check-input-helpers.R
+++ b/R/check-input-helpers.R
@@ -108,8 +108,8 @@ check_number_per_forecast <- function(data, forecast_unit) {
 #' @inheritParams get_duplicate_forecasts
 #' @inherit document_check_functions return
 #' @keywords internal_input_check
-check_duplicates <- function(data, forecast_unit = get_forecast_unit(data)) {
-  check_duplicates <- get_duplicate_forecasts(data, forecast_unit = forecast_unit)
+check_duplicates <- function(data) {
+  check_duplicates <- get_duplicate_forecasts(data)
 
   if (nrow(check_duplicates) > 0) {
     msg <- paste0(

--- a/R/forecast.R
+++ b/R/forecast.R
@@ -314,7 +314,7 @@ validate_general <- function(data) {
 
   # check that there aren't any duplicated forecasts
   forecast_unit <- get_forecast_unit(data)
-  assert(check_duplicates(data, forecast_unit = forecast_unit))
+  assert(check_duplicates(data))
 
   # check that the number of forecasts per sample / quantile level is the same
   number_quantiles_samples <- check_number_per_forecast(data, forecast_unit)

--- a/R/get_-functions.R
+++ b/R/get_-functions.R
@@ -300,7 +300,7 @@ get_duplicate_forecasts <- function(
   data
 ) {
   assert_data_frame(data)
-  forecast_unit = get_forecast_unit(data)
+  forecast_unit <- get_forecast_unit(data)
   available_type <- c("sample_id", "quantile_level") %in% colnames(data)
   type <- c("sample_id", "quantile_level")[available_type]
   data <- as.data.table(data)

--- a/R/get_-functions.R
+++ b/R/get_-functions.R
@@ -288,10 +288,6 @@ get_protected_columns <- function(data = NULL) {
 #'
 #' @param data A data.frame as used for [score()]
 #'
-#' @param forecast_unit A character vector with the column names that define
-#'   the unit of a single forecast. By default the forecast unit will be
-#'   automatically inferred from the data (see [get_forecast_unit()])
-#'
 #' @return A data.frame with all rows for which a duplicate forecast was found
 #' @export
 #' @importFrom checkmate assert_data_frame assert_subset
@@ -301,11 +297,10 @@ get_protected_columns <- function(data = NULL) {
 #' get_duplicate_forecasts(example)
 
 get_duplicate_forecasts <- function(
-  data,
-  forecast_unit = get_forecast_unit(data)
+  data
 ) {
   assert_data_frame(data)
-  assert_subset(forecast_unit, colnames(data))
+  forecast_unit = get_forecast_unit(data)
   available_type <- c("sample_id", "quantile_level") %in% colnames(data)
   type <- c("sample_id", "quantile_level")[available_type]
   data <- as.data.table(data)

--- a/man/check_duplicates.Rd
+++ b/man/check_duplicates.Rd
@@ -4,14 +4,10 @@
 \alias{check_duplicates}
 \title{Check that there are no duplicate forecasts}
 \usage{
-check_duplicates(data, forecast_unit = get_forecast_unit(data))
+check_duplicates(data)
 }
 \arguments{
 \item{data}{A data.frame as used for \code{\link[=score]{score()}}}
-
-\item{forecast_unit}{A character vector with the column names that define
-the unit of a single forecast. By default the forecast unit will be
-automatically inferred from the data (see \code{\link[=get_forecast_unit]{get_forecast_unit()}})}
 }
 \value{
 Returns TRUE if the check was successful and a string with an

--- a/man/get_duplicate_forecasts.Rd
+++ b/man/get_duplicate_forecasts.Rd
@@ -4,14 +4,10 @@
 \alias{get_duplicate_forecasts}
 \title{Find duplicate forecasts}
 \usage{
-get_duplicate_forecasts(data, forecast_unit = get_forecast_unit(data))
+get_duplicate_forecasts(data)
 }
 \arguments{
 \item{data}{A data.frame as used for \code{\link[=score]{score()}}}
-
-\item{forecast_unit}{A character vector with the column names that define
-the unit of a single forecast. By default the forecast unit will be
-automatically inferred from the data (see \code{\link[=get_forecast_unit]{get_forecast_unit()}})}
 }
 \value{
 A data.frame with all rows for which a duplicate forecast was found


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #693.

As described in #693. This PR removes the `forecast_unit` arg from 
- `get_duplicate_forecasts()` 
- `check_duplicates()` (which maybe should be `check_duplicate_forecasts()`, but then again it's internal anyway)

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
