### PR TITLE
Issue #309 - fix error in bias quantile documentation

### DIFF
--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -399,10 +399,12 @@ interval_coverage_deviation <- function(observed, predicted, quantile_level) {
 #'
 #' In clearer terms, bias \eqn{B_t} is:
 #' - \eqn{1 - 2 \cdot} the maximum percentile rank for which the corresponding
-#' quantile is still below the observed value, *if the observed value is smaller
-#' than the median of the predictive distribution.*
+#' quantile is still smaller than or equal to the observed value,
+#' *if the observed value is smaller than the median of the predictive
+#' distribution.*
 #' - \eqn{1 - 2 \cdot} the minimum percentile rank for which the corresponding
-#' quantile is still larger than the true value *if the observed value is larger
+#' quantile is still larger than or equal to the observed value *if the observed
+#' value is larger
 #' than the median of the predictive distribution.*.
 #' - \eqn{0} *if the observed value is exactly the median* (both terms cancel
 #' out)

--- a/man/bias_quantile.Rd
+++ b/man/bias_quantile.Rd
@@ -50,10 +50,12 @@ condition is satisfied and \eqn{0} otherwise.
 In clearer terms, bias \eqn{B_t} is:
 \itemize{
 \item \eqn{1 - 2 \cdot} the maximum percentile rank for which the corresponding
-quantile is still below the observed value, \emph{if the observed value is smaller
-than the median of the predictive distribution.}
+quantile is still smaller than or equal to the observed value,
+\emph{if the observed value is smaller than the median of the predictive
+distribution.}
 \item \eqn{1 - 2 \cdot} the minimum percentile rank for which the corresponding
-quantile is still larger than the true value \emph{if the observed value is larger
+quantile is still larger than or equal to the observed value \emph{if the observed
+value is larger
 than the median of the predictive distribution.}.
 \item \eqn{0} \emph{if the observed value is exactly the median} (both terms cancel
 out)


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #309.

This PR makes a small change to the documentation of `bias_quantile()`, making sure that the verbal description (smaller/greater than or equal to) matches the >= and <= in the formula. 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
