### PR TITLE
Correct docs for brier score

### DIFF
--- a/R/metrics-binary.R
+++ b/R/metrics-binary.R
@@ -48,12 +48,11 @@ NULL
 #' rule. Small values are better (best is 0, the worst is 1).
 #'
 #' \deqn{
-#'   \textrm{Brier\_Score} = \frac{1}{N} \sum_{t = 1}^{n} (\textrm{prediction}_t -
-#'   \textrm{outcome}_t)^2,
+#'   \textrm{Brier\_Score} = (\textrm{prediction} - \textrm{outcome})^2,
 #' }{
-#'   Brier_Score = 1/N sum_{t = 1}^{n} (prediction_t - outcome_t)²,
-#' } where \eqn{\textrm{outcome}_t \in \{0, 1\}}{outcome_t in {0, 1}}, and
-#' \eqn{\textrm{prediction}_t \in [0, 1]}{prediction_t in [0, 1]} represents
+#'   Brier_Score = (prediction - outcome)²,
+#' } where \eqn{\textrm{outcome} \in \{0, 1\}}{outcome in {0, 1}}, and
+#' \eqn{\textrm{prediction} \in [0, 1]}{prediction in [0, 1]} represents
 #' the probability that the outcome is equal to 1.
 #' @return A numeric vector of size n with the Brier scores
 #' @keywords metric

--- a/man/scoring-functions-binary.Rd
+++ b/man/scoring-functions-binary.Rd
@@ -34,12 +34,11 @@ prediction and the observed outcome. The Brier score is a proper scoring
 rule. Small values are better (best is 0, the worst is 1).
 
 \deqn{
-  \textrm{Brier\_Score} = \frac{1}{N} \sum_{t = 1}^{n} (\textrm{prediction}_t -
-  \textrm{outcome}_t)^2,
+  \textrm{Brier\_Score} = (\textrm{prediction} - \textrm{outcome})^2,
 }{
-  Brier_Score = 1/N sum_{t = 1}^{n} (prediction_t - outcome_t)²,
-} where \eqn{\textrm{outcome}_t \in \{0, 1\}}{outcome_t in {0, 1}}, and
-\eqn{\textrm{prediction}_t \in [0, 1]}{prediction_t in [0, 1]} represents
+  Brier_Score = (prediction - outcome)²,
+} where \eqn{\textrm{outcome} \in \{0, 1\}}{outcome in {0, 1}}, and
+\eqn{\textrm{prediction} \in [0, 1]}{prediction in [0, 1]} represents
 the probability that the outcome is equal to 1.
 
 \strong{Log score for binary outcomes}


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #<issue-number>.

The current version of the docs has a 1/N term in them. However, we don't return the average Brier score, but instead return the element-wise Brier score. This PR corrects that by getting rid of the 1/N part. 

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] I have built the package locally and run rebuilt docs using roxygen2.
- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
