### PR TITLE
Ensure that summarise_scores() works with a data.frame or similar

### DIFF
--- a/R/get_-functions.R
+++ b/R/get_-functions.R
@@ -158,18 +158,23 @@ get_type <- function(x) {
 #' become column names of the
 #' resulting data.table. In addition, an attribute `metrics` will be
 #' added to the output, holding the names of the scores as a vector.
-#' This is done so that a function like [get_forecast_unit()] can still
-#' identify which columns are part of the forecast unit and which hold a score.
 #'
-#' `get_metrics()` access and returns this attribute. If there is no
-#' attribute, the function will return NULL. Users can control whether the
-#' function should error instead via the `error` argument.
+#' This is done so that functions like [get_forecast_unit()] or
+#' [summarise_scores()] can still identify which columns are part of the
+#' forecast unit and which hold a score.
 #'
-#' `get_metrics()` also checks whether the names of the scores stored in
-#' the attribute are column names of the data and will throw a warning if not.
-#' This can happen if you rename columns after scoring. You can either run
-#' [score()] again, specifying names for the scoring rules manually, or you
-#' can update the attribute manually using
+#' `get_metrics()` accesses and returns the `metrics` attribute. If there is no
+#' attribute, the function will return `NULL` (or, if `error = TRUE` will
+#' produce an error instead). In addition, it checks the column names of the
+#' input for consistency with the data stored in the `metrics` attribute.
+#'
+#' **Handling a missing or inconsistent `metrics` attribute**:
+#'
+#' If the metrics attribute is missing or is not consistent with the column
+#' names of the data.table, you can either
+#'
+#' - run [score()] again, specifying names for the scoring rules manually, or
+#' - add/update the attribute manually using
 #' `attr(scores, "metrics") <- c("names", "of", "your", "scores")` (the
 #' order does not matter).
 #'

--- a/R/summarise_scores.R
+++ b/R/summarise_scores.R
@@ -63,6 +63,7 @@ summarise_scores <- function(scores,
                              ...) {
   # input checking ------------------------------------------------------------
   assert_data_frame(scores)
+  scores <- ensure_data.table(scores)
   assert_subset(by, names(scores), empty.ok = TRUE)
   assert_subset(across, names(scores), empty.ok = TRUE)
   assert_function(fun)

--- a/man/get_metrics.Rd
+++ b/man/get_metrics.Rd
@@ -21,19 +21,25 @@ When applying a scoring rule via \code{\link[=score]{score()}}, the names of the
 become column names of the
 resulting data.table. In addition, an attribute \code{metrics} will be
 added to the output, holding the names of the scores as a vector.
-This is done so that a function like \code{\link[=get_forecast_unit]{get_forecast_unit()}} can still
-identify which columns are part of the forecast unit and which hold a score.
 
-\code{get_metrics()} access and returns this attribute. If there is no
-attribute, the function will return NULL. Users can control whether the
-function should error instead via the \code{error} argument.
+This is done so that functions like \code{\link[=get_forecast_unit]{get_forecast_unit()}} or
+\code{\link[=summarise_scores]{summarise_scores()}} can still identify which columns are part of the
+forecast unit and which hold a score.
 
-\code{get_metrics()} also checks whether the names of the scores stored in
-the attribute are column names of the data and will throw a warning if not.
-This can happen if you rename columns after scoring. You can either run
-\code{\link[=score]{score()}} again, specifying names for the scoring rules manually, or you
-can update the attribute manually using
+\code{get_metrics()} accesses and returns the \code{metrics} attribute. If there is no
+attribute, the function will return \code{NULL} (or, if \code{error = TRUE} will
+produce an error instead). In addition, it checks the column names of the
+input for consistency with the data stored in the \code{metrics} attribute.
+
+\strong{Handling a missing or inconsistent \code{metrics} attribute}:
+
+If the metrics attribute is missing or is not consistent with the column
+names of the data.table, you can either
+\itemize{
+\item run \code{\link[=score]{score()}} again, specifying names for the scoring rules manually, or
+\item add/update the attribute manually using
 \code{attr(scores, "metrics") <- c("names", "of", "your", "scores")} (the
 order does not matter).
+}
 }
 \keyword{check-forecasts}

--- a/tests/testthat/test-summarise_scores.R
+++ b/tests/testthat/test-summarise_scores.R
@@ -49,6 +49,13 @@ test_that("summarise_scores() handles the `metrics` attribute correctly", {
   )
 })
 
+test_that("summarise_scores() handles data.frames correctly", {
+  test <- as.data.frame(scores_quantile)
+  expect_no_condition(
+    summarise_scores(test, by = "model")
+  )
+})
+
 test_that("summarise_scores() across argument works as expected", {
   ex <- data.table::copy(example_quantile)
   ex <- suppressMessages(as_forecast(ex))


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #804. 

As discussed in #804, `summarise_scores()` currently doesn't produce a helpful warning when you pass in a `data.frame`. This PR updates `summarise_score()` such that it also handles a `data.frame` as input (provided, that a `metrics` attribute is present. 

Thank you to @damonbayer for raising this point! 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] ~I have added a news item linked to this PR.~
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
