### PR TITLE
Issue #855 - render readme as PR

### DIFF
--- a/.github/workflows/render_readme.yaml
+++ b/.github/workflows/render_readme.yaml
@@ -7,9 +7,8 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    paths:
-      - 'README.Rmd'
-      - DESCRIPTION
+    branches:
+      - main
 
 jobs:
   render-readme:
@@ -29,17 +28,35 @@ jobs:
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rmarkdown, local::.
+          extra-packages: any::rmarkdown, local::., any::allcontributors
 
+      - name: Update contributors
+        if: github.ref == 'refs/heads/main'
+        run: allcontributors::add_contributors(format = "text")
+        shell: Rscript {0}
+        
       - name: Compile the readme
         run: |
           rmarkdown::render("README.Rmd")
         shell: Rscript {0}
 
-      - name: Commit files
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add README.md man/figures/
-          git diff-index --quiet HEAD || git commit -m "Automatic readme update [ci skip]"
-          git push origin || echo "No changes to push"
+      - name: Upload README.md as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: readme
+          path: README.md
+
+      - name: Create Pull Request
+        if: github.ref == 'refs/heads/main'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Automatic README update"
+          title: "Update README"
+          body: "This is an automated pull request to update the README."
+          branch: "update-readme-${{ github.run_number }}"
+          labels: "documentation"
+          reviewers: nikosbosse
+          add-paths: |
+            README.Rmd
+            README.md
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.Rmd
+++ b/README.Rmd
@@ -154,3 +154,5 @@ We welcome contributions and new contributors! We particularly appreciate help o
 ## Code of Conduct
   
 Please note that the `scoringutils` project is released with a [Contributor Code of Conduct](https://epiforecasts.io/scoringutils/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.
+
+## Contributors


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #855.

As discussed in the issue, this PR steals the render-readme yaml from the excellent `epinowcast` package. 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
