### PR TITLE
issue #827 - Improve error handling for wis()

### DIFF
--- a/R/utils_data_handling.R
+++ b/R/utils_data_handling.R
@@ -121,6 +121,19 @@ quantile_to_interval_dataframe <- function(forecast,
     forecast[, quantile_level := NULL]
   }
 
+  if (length(unique(forecast$boundary)) < 2) {
+    cli_abort(
+      c(
+        #nolint start: keyword_quote_linter
+        `!` = "No valid forecast intervals found.",
+        `i` = "A forecast interval comprises two
+      quantiles with quantile levels symmetric around the median
+      (e.g. 0.25 and 0.75)"
+        #nolint end
+      )
+    )
+  }
+
   if (format == "wide") {
     suppressWarnings(forecast[, "quantile_level" := NULL])
     forecast <- dcast(forecast, ... ~ boundary, value.var = "predicted")

--- a/tests/testthat/test-metrics-quantile.R
+++ b/tests/testthat/test-metrics-quantile.R
@@ -558,6 +558,20 @@ test_that("Quantlie score and interval score yield the same result, weigh = FALS
 })
 
 
+test_that("wis errors when there are no valid forecast intervals", {
+  # test that wis throws an error when there are no valid forecast intervals
+  # (i.e. the quantiles do not form central prediction intervals)
+  observed <- 0.1
+  predicted <- c(0.1032978, 0.1078166, 0.1906849, 0.1969254, 0.2017249, 0.2078487, 0.2810377, 0.3062168, 0.4006721, 0.8219655)
+  quantile_level <- c(0.600, 0.650, 0.700, 0.750, 0.800, 0.850, 0.900, 0.950, 0.975, 0.990)
+
+  expect_error(
+    wis(observed, predicted, quantile_level),
+    "No valid forecast intervals found."
+  )
+})
+
+
 # ============================================================================ #
 # Quantile score ============================================================= #
 # ============================================================================ #


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #827.

As discussed in #827, `wis()` didn't give a very informative error when there were no valid quantiles left. This PR changes `quantile_to_interval_dataframe` to throw an error when there are no valid intervals. This function is an internal function and I think you'd never want it to succeed if it wasn't able to produce a single valid forecast interval. 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
