### PR TITLE
Mention purrr partial in the docs

### DIFF
--- a/R/default-scoring-rules.R
+++ b/R/default-scoring-rules.R
@@ -45,7 +45,7 @@ select_metrics <- function(metrics, select = NULL, exclude = NULL) {
 #' @description
 #' This function takes a metric function and additional arguments, and returns
 #' a new function that includes the additional arguments when calling the
-#' original metric function.
+#' original metric function. The function is equivalent to `purrr::partial()`.
 #'
 #' This is the expected way to pass additional
 #' arguments to a metric when evaluating a forecast using [score()]:

--- a/man/customise_metric.Rd
+++ b/man/customise_metric.Rd
@@ -21,7 +21,7 @@ A customised metric function.
 \description{
 This function takes a metric function and additional arguments, and returns
 a new function that includes the additional arguments when calling the
-original metric function.
+original metric function. The function is equivalent to \code{purrr::partial()}.
 
 This is the expected way to pass additional
 arguments to a metric when evaluating a forecast using \code{\link[=score]{score()}}:


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #820.

We had a bit of a back-and-forth in #820. The question was whether to keep `customise_metric()` or to officially replace ith with `purrr::partial()`. This PR adds a comment to the docs that `customise_metric()` is essentially the same as `purrr::partial()`. Also opening up the floor if people have more thoughts on it :) 
@sbfnk

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
