### PR TITLE
Use ASCII hypen

### DIFF
--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -618,7 +618,7 @@ ae_median_quantile <- function(observed, predicted, quantile_level) {
 #' The quantile score, also called pinball loss, for a single quantile
 #' level \eqn{\tau} is defined as
 #' \deqn{
-#'   \text{QS}_\tau(F, y) = 2 \cdot \{ \mathbf{1}(y \leq q_\tau) - \tau\} \cdot (q_\tau − y) =
+#'   \text{QS}_\tau(F, y) = 2 \cdot \{ \mathbf{1}(y \leq q_\tau) - \tau\} \cdot (q_\tau - y) =
 #'   \begin{cases}
 #' 2 \cdot (1 - \tau) * q_\tau - y,       & \text{if } y \leq q_\tau\\
 #' 2 \cdot \tau * |q_\tau - y|,           & \text{if } y > q_\tau,

--- a/man/quantile_score.Rd
+++ b/man/quantile_score.Rd
@@ -43,7 +43,7 @@ central prediction intervals.
 The quantile score, also called pinball loss, for a single quantile
 level \eqn{\tau} is defined as
 \deqn{
-  \text{QS}_\tau(F, y) = 2 \cdot \{ \mathbf{1}(y \leq q_\tau) - \tau\} \cdot (q_\tau − y) =
+  \text{QS}_\tau(F, y) = 2 \cdot \{ \mathbf{1}(y \leq q_\tau) - \tau\} \cdot (q_\tau - y) =
   \begin{cases}
 2 \cdot (1 - \tau) * q_\tau - y,       & \text{if } y \leq q_\tau\\
 2 \cdot \tau * |q_\tau - y|,           & \text{if } y > q_\tau,

--- a/vignettes/scoring-rules.Rmd
+++ b/vignettes/scoring-rules.Rmd
@@ -390,7 +390,7 @@ See section [A note of caution] or @gneitingMakingEvaluatingPoint2011 for a disc
 The quantile score, also called pinball loss, for a single quantile level $\tau$ is defined as
 
 \begin{equation}
-    \text{QS}_\tau(F, y) = 2 \cdot \{ \mathbf{1}(y \leq q_\tau) - \tau\} \cdot (q_\tau − y) = 
+    \text{QS}_\tau(F, y) = 2 \cdot \{ \mathbf{1}(y \leq q_\tau) - \tau\} \cdot (q_\tau - y) = 
     \begin{cases}
         2 \cdot (1 - \tau) * q_\tau - y,       & \text{if } y \leq q_\tau\\
         2 \cdot \tau * |q_\tau - y|,           & \text{if } y > q_\tau, 


### PR DESCRIPTION
Got this `R CMD check` error:

```
* checking PDF version of manual ... WARNING
LaTeX errors when creating PDF version.
This typically indicates Rd problems.
LaTeX errors found:
! LaTeX Error: Unicode character − (U+2212)
               not set up for use with LaTeX.
```

Probably, this is a deficiency of the system (a Docker container) where I'm running `R CMD check`. But anyway, a hyphen seems more appropriate here.