### PR TITLE
ns-qualify as.data.table() for R CMD check

### DIFF
--- a/R/score.R
+++ b/R/score.R
@@ -237,7 +237,7 @@ apply_metrics <- function(forecast, metrics, ...) {
 #' @param scores A data.table or similar with scores as produced by [score()].
 #' @param metrics A character vector with the names of the scores
 #'   (i.e. the names of the scoring rules used for scoring).
-#' @param ... Additional arguments to [as.data.table()]
+#' @param ... Additional arguments to [data.table::as.data.table()]
 #' @keywords internal
 #' @importFrom data.table as.data.table setattr
 #' @return An object of class `scores`

--- a/man/new_scores.Rd
+++ b/man/new_scores.Rd
@@ -12,7 +12,7 @@ new_scores(scores, metrics, ...)
 \item{metrics}{A character vector with the names of the scores
 (i.e. the names of the scoring rules used for scoring).}
 
-\item{...}{Additional arguments to \code{\link[=as.data.table]{as.data.table()}}}
+\item{...}{Additional arguments to \code{\link[data.table:as.data.table]{as.data.table()}}}
 }
 \value{
 An object of class \code{scores}


### PR DESCRIPTION
Currently seeing this `NOTE` in `R CMD check` on devel:

```
* checking Rd cross-references ... NOTE
Found the following Rd file(s) with Rd \link{} targets missing package
anchors:
  new_scores.Rd: as.data.table
```