### PR TITLE
Fix inheritance order

### DIFF
--- a/R/forecast.R
+++ b/R/forecast.R
@@ -436,7 +436,7 @@ clean_forecast <- function(forecast, copy = FALSE, na.omit = FALSE) {
 new_forecast <- function(data, classname) {
   data <- as.data.table(data)
   data <- ensure_model_column(data)
-  class(data) <- c("forecast", classname, class(data))
+  class(data) <- c(classname, "forecast", class(data))
   data <- copy(data)
   return(data[])
 }

--- a/tests/testthat/test-forecast.R
+++ b/tests/testthat/test-forecast.R
@@ -20,7 +20,7 @@ test_that("as_forecast() works as expected", {
 
   expect_s3_class(
     as_forecast_quantile(test),
-    c("forecast", "forecast_quantile", "data.table", "data.frame"),
+    c("forecast_quantile", "forecast", "data.table", "data.frame"),
     exact = TRUE)
 
   # expect error when arguments are not correct

--- a/tests/testthat/test-get_-functions.R
+++ b/tests/testthat/test-get_-functions.R
@@ -71,7 +71,7 @@ test_that("removing NA rows from data works as expected", {
   ex <- as_forecast_sample(na.omit(example_sample_discrete))
   expect_s3_class(
     na.omit(ex),
-    c("forecast", "forecast_sample", "data.table", "data.frame"),
+    c("forecast_sample", "forecast", "data.table", "data.frame"),
     exact = TRUE
   )
 


### PR DESCRIPTION
The `"forecast_sample"`, etc. are a subclass of `"forecast"` so the order in the class attribute needs to be reversed for correct dispatch.
