### PR TITLE
#931 - Fix data.table issue caused by `attr()`

### DIFF
--- a/R/score.R
+++ b/R/score.R
@@ -349,12 +349,13 @@ validate_scores <- function(scores) {
   return(invisible(NULL))
 }
 
-##' @method `[` scores
-##' @export
+#' @method `[` scores
+#' @importFrom data.table setattr
+#' @export
 `[.scores` <- function(x, ...) {
   ret <- NextMethod()
-  if (is.data.frame(ret)) {
-    attr(ret, "metrics") <- attr(x, "metrics")
+  if (is.data.table(ret)) {
+    setattr(ret, "metrics", attr(x, "metrics"))
   }
   return(ret)
 }

--- a/R/score.R
+++ b/R/score.R
@@ -356,6 +356,8 @@ validate_scores <- function(scores) {
   ret <- NextMethod()
   if (is.data.table(ret)) {
     setattr(ret, "metrics", attr(x, "metrics"))
+  } else if (is.data.frame(ret)) {
+    attr(ret, "metrics") <- attr(x, "metrics")
   }
   return(ret)
 }

--- a/tests/testthat/test-score.R
+++ b/tests/testthat/test-score.R
@@ -61,6 +61,14 @@ test_that("function throws an error if data is not a forecast object", {
 #   expect_warning(suppressMessages(score(forecast = data)))
 # })
 
+test_that("Manipulating scores objects with .[ works as expected", {
+  expect_no_condition(scores_point[1:10])
+
+  expect_no_condition(scores_point[, .(model, ae_point)])
+
+  ex <- score(example_quantile)
+  expect_no_condition(ex[, extra_col := "something"])
+})
 
 
 # test binary case -------------------------------------------------------------


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #931 

As discussed in #931, manipulating `scores` objects caused a warning due to the use of `attr()` in `[.scores`. This PR replaces `attr()` with `setatrr()` and adds some tests. 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
