### PR TITLE
Handling case in WIS where quantile levels don't form valid intervals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -88,6 +88,7 @@ of our [original](https://doi.org/10.48550/arXiv.2205.07090) `scoringutils` pape
 ### Function changes
 - `bias_quantile()` changed the way it handles forecasts where the median is missing: The median is now imputed by linear interpolation between the innermost quantiles. Previously, we imputed the median by simply taking the mean of the innermost quantiles.
 - In contrast to the previous `correlation` function, `get_correlations` doesn't round correlations by default. Instead, `plot_correlations` now has a `digits` argument that allows users to round correlations before plotting them. Alternatively, using `dplyr`, you could call something like `mutate(correlations, across(where(is.numeric), \(x) signif(x, digits = 2)))` on the output of `get_correlations`. 
+- `wis()` now errors by default if not all quantile levels form valid prediction intervals.
 
 ### Internal package updates
 - The deprecated `..density..` was replaced with `after_stat(density)` in ggplot calls.

--- a/NEWS.md
+++ b/NEWS.md
@@ -88,7 +88,7 @@ of our [original](https://doi.org/10.48550/arXiv.2205.07090) `scoringutils` pape
 ### Function changes
 - `bias_quantile()` changed the way it handles forecasts where the median is missing: The median is now imputed by linear interpolation between the innermost quantiles. Previously, we imputed the median by simply taking the mean of the innermost quantiles.
 - In contrast to the previous `correlation` function, `get_correlations` doesn't round correlations by default. Instead, `plot_correlations` now has a `digits` argument that allows users to round correlations before plotting them. Alternatively, using `dplyr`, you could call something like `mutate(correlations, across(where(is.numeric), \(x) signif(x, digits = 2)))` on the output of `get_correlations`. 
-- `wis()` now errors by default if not all quantile levels form valid prediction intervals.
+- `wis()` now errors by default if not all quantile levels form valid prediction intervals and returns `NA` if there are missing values. Previously, `na.rm` was set to `TRUE` by default, which could lead to unexpected results, if users are not aware of this.
 
 ### Internal package updates
 - The deprecated `..density..` was replaced with `after_stat(density)` in ggplot calls.

--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -190,9 +190,9 @@ wis <- function(observed,
   )
   complete_intervals <-
     duplicated(interval_ranges) | duplicated(interval_ranges, fromLast = TRUE)
-  if (any(!complete_intervals) && !na.rm) {
+  if (!all(complete_intervals) && !na.rm) {
+    #nolint start: keyword_quote_linter object_usage_linter
     incomplete <- quantile_level[quantile_level != 0.5][!complete_intervals]
-    #nolint start: keyword_quote_linter
     cli_abort(
       c(
         "!" = "Not all quantile levels specified form symmetric prediction

--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -180,9 +180,30 @@ wis <- function(observed,
                 separate_results = FALSE,
                 weigh = TRUE,
                 count_median_twice = FALSE,
-                na.rm = TRUE) {
+                na.rm = FALSE) {
   assert_input_quantile(observed, predicted, quantile_level)
   reformatted <- quantile_to_interval(observed, predicted, quantile_level)
+
+  # check that all quantile levels form valid prediction intervals
+  interval_ranges <- get_range_from_quantile(
+    quantile_level[quantile_level != 0.5]
+  )
+  complete_intervals <-
+    duplicated(interval_ranges) | duplicated(interval_ranges, fromLast = TRUE)
+  if (any(!complete_intervals) && !na.rm) {
+    incomplete <- quantile_level[quantile_level != 0.5][!complete_intervals]
+    #nolint start: keyword_quote_linter
+    cli_abort(
+      c(
+        "!" = "Not all quantile levels specified form symmetric prediction
+        intervals.
+        The following quantile levels miss a corresponding lower/upper bound:
+        {.val {incomplete}}.
+        You can drop incomplete prediction intervals using `na.rm = TRUE`."
+      )
+    )
+    #nolint end
+  }
 
   assert_logical(separate_results, len = 1)
   assert_logical(weigh, len = 1)

--- a/R/metrics-quantile.R
+++ b/R/metrics-quantile.R
@@ -190,7 +190,7 @@ wis <- function(observed,
   )
   complete_intervals <-
     duplicated(interval_ranges) | duplicated(interval_ranges, fromLast = TRUE)
-  if (!all(complete_intervals) && !na.rm) {
+  if (!all(complete_intervals) && !isTRUE(na.rm)) {
     #nolint start: keyword_quote_linter object_usage_linter
     incomplete <- quantile_level[quantile_level != 0.5][!complete_intervals]
     cli_abort(

--- a/man/wis.Rd
+++ b/man/wis.Rd
@@ -14,7 +14,7 @@ wis(
   separate_results = FALSE,
   weigh = TRUE,
   count_median_twice = FALSE,
-  na.rm = TRUE
+  na.rm = FALSE
 )
 
 dispersion_quantile(observed, predicted, quantile_level, ...)


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #926.

As discussed in #926, this PR lets `wis()` error by default if not all quantile levels form valid prediction intervals. I realised that there was a `na.rm` argument already (it was just set to `TRUE`). I think `FALSE` is a better default. 
If the quantile levels aren't symmetric, the function errors immediately. 

(Note that there is a second way in which `na.rm` can be relevant: if a specific quantile is missing for a forecast. With `na.rm = TRUE` `NA` values will be dropped and otherwise the output is `NA`.)

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
