### PR TITLE
Issuel #952 - Fix get_forecast_type

### DIFF
--- a/R/get-forecast-type.R
+++ b/R/get-forecast-type.R
@@ -4,14 +4,14 @@
 #' Character vector of length one with the forecast type.
 #' @keywords internal_input_check
 get_forecast_type <- function(forecast) {
-  classname <- class(forecast)[1]
-  if (grepl("forecast_", classname, fixed = TRUE)) {
-    type <- gsub("forecast_", "", classname, fixed = TRUE)
-    return(type)
+  classname <- class(forecast)
+  forecast_class <- classname[grepl("forecast_", classname, fixed = TRUE)]
+  if (length(forecast_class) == 1) {
+    return(gsub("forecast_", "", forecast_class, fixed = TRUE))
   } else {
     cli_abort(
       "Input is not a valid forecast object
-      (it's first class should begin with `forecast_`)."
+      (There should be a single class beginning with `forecast_`)."
     )
   }
 }

--- a/tests/testthat/test-get-forecast-type.R
+++ b/tests/testthat/test-get-forecast-type.R
@@ -21,6 +21,11 @@ test_that("get_forecast_type() works as expected", {
     get_forecast_type(test),
     "Input is not a valid forecast object",
   )
+
+  # get_forecast_type() should still work even if a new class is added
+  testclassobject <- data.table::copy(example_quantile)
+  class(testclassobject) <- c("something", class(testclassobject))
+  expect_equal(get_forecast_type(testclassobject), "quantile")
 })
 
 


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #952.

Updates the function to check for a class named `forecast_` rather than only checking the first class

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] I have built the package locally and run rebuilt docs using roxygen2.
- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
