### PR TITLE
Remove function that resulted in an error when called from within print.data.table()

### DIFF
--- a/R/class-forecast.R
+++ b/R/class-forecast.R
@@ -272,7 +272,12 @@ is_forecast <- function(x) {
   #   undesired situation if we set ...length() > 1
   # is.data.table: when [.data.table returns an atomic vector, it's clear it
   #   cannot be a valid forecast object, and it is likely intended by the user
-  if (data.table::is.data.table(out) && !is_dt_force_print) {
+
+  # in addition, we also check for a maximum length. The reason is that
+  # print.data.table will internally subset the data.table before printing.
+  # this subsetting triggers the validation, which is not desired in this case.
+  # this is a hack and ideally, we'd do things differently.
+  if (nrow(out) > 30 && data.table::is.data.table(out) && !is_dt_force_print) {
     # check whether subset object passes validation
     validation <- try(
       assert_forecast(forecast = out, verbose = FALSE),
@@ -281,7 +286,10 @@ is_forecast <- function(x) {
     if (inherits(validation, "try-error")) {
       cli_warn(
         c(
-          "!" = "Error in validating forecast object: {validation}"
+          "!" = "Error in validating forecast object: {validation}.",
+          "i" = "Note this error is sometimes related to `data.table`s `print`.
+          Run {.help [{.fun assert_forecast}](scoringutils::assert_forecast)}
+          to confirm."
         )
       )
     }

--- a/R/class-forecast.R
+++ b/R/class-forecast.R
@@ -285,12 +285,14 @@ is_forecast <- function(x) {
     )
     if (inherits(validation, "try-error")) {
       cli_warn(
+        #nolint start: keyword_quote_linter
         c(
           "!" = "Error in validating forecast object: {validation}.",
           "i" = "Note this error is sometimes related to `data.table`s `print`.
           Run {.help [{.fun assert_forecast}](scoringutils::assert_forecast)}
           to confirm."
         )
+        #nolint end
       )
     }
   }

--- a/tests/testthat/test-class-forecast-nominal.R
+++ b/tests/testthat/test-class-forecast-nominal.R
@@ -53,3 +53,13 @@ test_that("get_metrics.forecast_nominal() works as expected", {
     is.list(get_metrics(example_nominal))
   )
 })
+
+
+# ==============================================================================
+# Printing
+# ==============================================================================
+test_that("Printing works as expected", {
+  expect_no_condition(
+    print(example_nominal)
+  )
+})

--- a/tests/testthat/test-class-forecast-nominal.R
+++ b/tests/testthat/test-class-forecast-nominal.R
@@ -59,7 +59,12 @@ test_that("get_metrics.forecast_nominal() works as expected", {
 # Printing
 # ==============================================================================
 test_that("Printing works as expected", {
-  expect_no_condition(
-    print(example_nominal)
+  suppressMessages(
+    expect_message(
+      expect_message(
+        capture.output(print(example_nominal)),
+        "Forecast type: nominal"
+      ),
+      "Forecast unit:")
   )
 })

--- a/tests/testthat/test-class-forecast.R
+++ b/tests/testthat/test-class-forecast.R
@@ -146,14 +146,14 @@ test_that("print() works on forecast_* objects", {
 test_that("print() throws the expected messages", {
   test <- data.table::copy(example_point)
   class(test) <- c("point", "forecast", "data.table", "data.frame")
-  expect_warning(
-    suppressMessages(
-      expect_message(
-        capture.output(print(test)),
-        "Could not determine forecast type due to error in validation."
-      )
-    ),
-    "Error in validating"
+
+  # note that since introducing a length maximum for validation to be triggered,
+  # we don't throw a warning automatically anymore
+  suppressMessages(
+    expect_message(
+      capture.output(print(test)),
+      "Could not determine forecast type due to error in validation."
+    )
   )
 
   class(test) <- c("forecast_point", "forecast")


### PR DESCRIPTION
## Description

This PR mostly gives up on #935. 

Previously, just calling `example_nominal` caused an error due to the subsetting that's happening within `print.data.table`. 

This function just removes the function that's responsible for it and adds a test. 
The issue that manipulating columns of a dt causes random printing still persists, sadly. But at least on error anymore. 


## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] I have built the package locally and run rebuilt docs using roxygen2.
- [ ] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
