### PR TITLE
Allow for numeric imprecision for ordinal forecasts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # scoringutils (development version)
 
+- Added tolerance for numeric errors when checking that probabilities sum to one in ordinal forecasts (#997)
+
 # scoringutils 2.1.0
 
 Minor spelling / mathematical updates to Scoring rule vignette. (#969)

--- a/R/metrics-nominal.R
+++ b/R/metrics-nominal.R
@@ -72,9 +72,12 @@ assert_input_categorical <- function(
     assert_matrix(predicted, nrows = n)
     summed_predictions <- round(rowSums(predicted, na.rm = TRUE), 10) # avoid numeric errors
   }
-  if (!all(summed_predictions == 1)) {
+  # Allow for numeric errors
+  tolerance <- 1e-8
+  invalid_rows <- abs(summed_predictions - 1) > tolerance
+  if (any(invalid_rows)) {
     #nolint start: keyword_quote_linter object_usage_linter
-    row_indices <- as.character(which(summed_predictions != 1))
+    row_indices <- which(invalid_rows)
     cli_abort(
       c(
         `!` = "Probabilities belonging to a single forecast must sum to one",

--- a/R/metrics-nominal.R
+++ b/R/metrics-nominal.R
@@ -73,8 +73,7 @@ assert_input_categorical <- function(
     summed_predictions <- round(rowSums(predicted, na.rm = TRUE), 10) # avoid numeric errors
   }
   # Allow for numeric errors
-  tolerance <- 1e-4
-  invalid_rows <- abs(summed_predictions - 1) > tolerance
+  invalid_rows <- abs(summed_predictions - 1) > 1e-4
   if (any(invalid_rows)) {
     #nolint start: keyword_quote_linter object_usage_linter
     row_indices <- which(invalid_rows)

--- a/R/metrics-nominal.R
+++ b/R/metrics-nominal.R
@@ -73,7 +73,7 @@ assert_input_categorical <- function(
     summed_predictions <- round(rowSums(predicted, na.rm = TRUE), 10) # avoid numeric errors
   }
   # Allow for numeric errors
-  tolerance <- 1e-8
+  tolerance <- 1e-4
   invalid_rows <- abs(summed_predictions - 1) > tolerance
   if (any(invalid_rows)) {
     #nolint start: keyword_quote_linter object_usage_linter


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #996 

As discussed in #996, this PR allows for some numeric imprecision when checking whether all probabilities sum to 1. 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
