### PR TITLE
Issue #1005 - Update dependency on scoringRules to >=1.1.2 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ Imports:
     methods,
     Metrics,
     purrr,
-    scoringRules,
+    scoringRules (>= 1.1.2),
     stats
 Suggests:
     ggdist,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - The package now depends on R version at least 4.1.0 as a result of downstream dependencies.
 - Added tolerance for numeric errors when checking that probabilities sum to one in ordinal forecasts (#997)
 - Made computation of p-values optional in pairwise comparisons by allowing `test_type = NULL` in `compare_forecasts()`. When `test_type = NULL`, p-values will be `NA` (#978).
+- Added a dependency on a scoringRules version >= 1.1.2 which is required for ordinal forecasts (#1006).
 
 # scoringutils 2.1.0
 


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #1005.

For scoring ordinal forecasts, we require functionality that was introduced in `scoringRules v1.1.2`. This PR therefore updates the dependency accordingly,

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title as follows: *issue-number*: PR title
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] I have built the package locally and run rebuilt docs using roxygen2.
- [x] My code follows the established coding standards and I have run `lintr::lint_package()` to check for style issues introduced by my changes. 
- [x] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @scoringutils dev team -->
