### PR TITLE
Issue #1021: Drop unused levels

### DIFF
--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -235,7 +235,7 @@ get_pairwise_comparisons <- function(
 
   # do the pairwise comparison -------------------------------------------------
   # split data set into groups determined by 'by'
-  split_scores <- split(scores, by = by)
+  split_scores <- split(scores, by = by, drop = TRUE)
 
   results <- lapply(split_scores,
     FUN = function(scores) {


### PR DESCRIPTION
This PR would drop unused levels in `get_pairwise_comparisons()`. This would ultimately alter e.g. `add_relative_skill()`. I was motivated to do this because I do not have complete data for all combinations of `by`. I don't think it should be a blocker if one has no data for a particular `by` combination (e.g. for me state, disease, and report date say).
