### PR TITLE
BOT: Fix #1022: allow pairwise comparisons with two models

### DIFF
--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -158,12 +158,12 @@ get_pairwise_comparisons <- function(
   assert_subset(baseline, comparators)
 
   # check there are enough comparators
-  if (length(setdiff(comparators, baseline)) < 2) {
+  if (!is.null(baseline) && length(setdiff(comparators, baseline)) < 2) {
     #nolint start: keyword_quote_linter
-    cli_abort(
+    cli_warn(
       c(
-        "!" = "More than one non-baseline model is needed to compute
-        pairwise compairisons."
+        "!" = "There is only one non-baseline model. Pairwise comparisons
+        will be based on a single ratio and may not be meaningful."
       )
     )
     #nolint end


### PR DESCRIPTION
## Summary
- Fixes #1022: `get_pairwise_comparisons()` now warns instead of erroring when there are exactly 2 models with one as the baseline
- Changed `cli_abort()` to `cli_warn()` for the two-model-with-baseline case, allowing the function to proceed and compute the single score ratio
- Fixed the "compairisons" typo in the warning message
- The single-model case (truly insufficient comparators) still errors via `pairwise_comparison_one_group()`

## Root cause
The check `length(setdiff(comparators, baseline)) < 2` at line 161 of `R/pairwise-comparisons.R` called `cli_abort()`, blocking the legitimate use case of comparing 2 models where one is the baseline. While the pairwise comparison is just a single ratio in this case, it's still useful output.

## What the fix does
- Adds `!is.null(baseline)` guard so the check only applies when a baseline is specified
- Changes `cli_abort()` to `cli_warn()` so the function proceeds with a warning
- Improves the warning message to be more informative

## Test coverage added
- `get_pairwise_comparisons()` warns but works with two models and a baseline
- `add_relative_skill()` warns but works with two models and a baseline
- Two-model ratio is mathematically correct (deterministic test with known values)
- Single-model case still errors (regression test)
- Two models without baseline still works without warning (regression test)
- Updated existing `expect_error` to `expect_warning` for the two-model-with-baseline case

## Test plan
- [x] New tests pass
- [x] Full test suite passes (695 tests, 0 failures)
- [x] R CMD check: 0 errors, 0 warnings, 2 pre-existing notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)