### PR TITLE
BOT: Fix #880: Add quantile_level parameter to as_forecast_point.forecast_quantile()

### DIFF
--- a/R/class-forecast-quantile.R
+++ b/R/class-forecast-quantile.R
@@ -99,12 +99,19 @@ is_forecast_quantile <- function(x) {
 #' @rdname as_forecast_point
 #' @description
 #' When converting a `forecast_quantile` object into a `forecast_point` object,
-#' the 0.5 quantile is extracted and returned as the point forecast.
+#' the quantile specified by `quantile_level` (default `0.5`, i.e. the median)
+#' is extracted and returned as the point forecast.
+#' @param quantile_level Numeric scalar specifying which quantile level to
+#'   extract as the point forecast. Defaults to `0.5` (the median). The
+#'   requested quantile level must be present in the data.
 #' @export
 #' @keywords as_forecast
-as_forecast_point.forecast_quantile <- function(data, ...) {
+#' @importFrom checkmate assert_number
+as_forecast_point.forecast_quantile <- function(data, quantile_level = 0.5,
+                                                ...) {
+  assert_number(quantile_level)
   assert_forecast(data, verbose = FALSE)
-  assert_subset(0.5, unique(data$quantile_level))
+  assert_subset(quantile_level, unique(data$quantile_level))
 
   # At end of this function, the object will have be turned from a
   # forecast_quantile to a forecast_point and we don't want to validate it as a
@@ -112,7 +119,8 @@ as_forecast_point.forecast_quantile <- function(data, ...) {
   # at the end.
   data <- as.data.table(data)
 
-  forecast <- data[quantile_level == 0.5]
+  target_quantile <- quantile_level
+  forecast <- data[quantile_level == target_quantile]
   forecast[, "quantile_level" := NULL]
 
   point_forecast <- new_forecast(forecast, "forecast_point")

--- a/man/as_forecast_point.Rd
+++ b/man/as_forecast_point.Rd
@@ -17,7 +17,7 @@ as_forecast_point(data, ...)
   ...
 )
 
-\method{as_forecast_point}{forecast_quantile}(data, ...)
+\method{as_forecast_point}{forecast_quantile}(data, quantile_level = 0.5, ...)
 }
 \arguments{
 \item{data}{A data.frame (or similar) with predicted and observed values.
@@ -38,13 +38,18 @@ observed values. This column will be renamed to "observed".}
 
 \item{predicted}{(optional) Name of the column in \code{data} that contains the
 predicted values. This column will be renamed to "predicted".}
+
+\item{quantile_level}{Numeric scalar specifying which quantile level to
+extract as the point forecast. Defaults to \code{0.5} (the median). The
+requested quantile level must be present in the data.}
 }
 \value{
 A \code{forecast} object of class \code{forecast_point}
 }
 \description{
 When converting a \code{forecast_quantile} object into a \code{forecast_point} object,
-the 0.5 quantile is extracted and returned as the point forecast.
+the quantile specified by \code{quantile_level} (default \code{0.5}, i.e. the median)
+is extracted and returned as the point forecast.
 }
 \section{Target format}{
 The input for all further scoring needs to be a data.frame or similar with


### PR DESCRIPTION
## Summary

- Fixes #880
- Adds a `quantile_level` parameter (default `0.5`) to `as_forecast_point.forecast_quantile()` so users can extract any quantile level as a point forecast, not just the hard-coded median
- The function previously hard-coded `0.5` in two places (the `assert_subset()` check and the filtering step), making it impossible to use a different quantile as the point forecast

## What was changed

- **`R/class-forecast-quantile.R`**: Added `quantile_level = 0.5` parameter with `checkmate::assert_number()` validation. Replaced hard-coded `0.5` references with the parameter value.
- **`man/as_forecast_point.Rd`**: Auto-generated documentation update reflecting the new parameter.
- **`tests/testthat/test-class-forecast-point.R`**: Added 5 new tests covering default behavior (regression guard), custom quantile level, missing quantile level error, invalid input validation, and correctness with manually constructed data.

## Test plan

- [x] All 5 new tests pass
- [x] Full test suite passes (691 tests, 0 failures)
- [x] R CMD check: 0 errors, 0 warnings, 2 pre-existing notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)