### PR TITLE
BOT: Fix #811: batch failed metric warnings into a single message

### DIFF
--- a/man/run_safely.Rd
+++ b/man/run_safely.Rd
@@ -15,7 +15,8 @@ run_safely(..., fun, metric_name)
 provide a more informative warning message in case \code{fun} errors.}
 }
 \value{
-The result of \code{fun} or \code{NULL} if \code{fun} errors
+The result of \code{fun}, or a list with \code{result = NULL} and \code{error}
+(a character string) if \code{fun} errors.
 }
 \description{
 This is a wrapper/helper function designed to run a function safely
@@ -24,7 +25,8 @@ function.
 
 All named arguments in \code{...} that are not accepted by \code{fun} are removed.
 All unnamed arguments are passed on to the function. In case \code{fun} errors,
-the error will be converted to a warning and \code{run_safely} returns \code{NULL}.
+\code{run_safely} returns a list with \code{result = NULL} and \code{error} containing the
+error message, allowing the caller to batch warnings.
 
 \code{run_safely} can be useful when constructing functions to be used as
 metrics in \code{\link[=score]{score()}}.

--- a/tests/testthat/test-class-forecast-quantile.R
+++ b/tests/testthat/test-class-forecast-quantile.R
@@ -364,15 +364,14 @@ test_that("score() works even if only some quantiles are missing", {
     scores_temp <- score(asymm, metrics = metrics)
     summarise_scores(scores_temp, by = "model")
   })
-  expect_warning(
-    expect_warning({
-      scores_temp <- score(asymm, metrics = metrics)
-      summarise_scores(scores_temp, by = "model")
-    },
-    "Computation for `interval_coverage_50` failed."
-    ),
-    "Computation for `interval_coverage_90` failed."
+  w <- expect_warning({
+    scores_temp <- score(asymm, metrics = metrics)
+    summarise_scores(scores_temp, by = "model")
+  },
+  "Computation failed for"
   )
+  expect_match(conditionMessage(w), "interval_coverage_50", fixed = TRUE)
+  expect_match(conditionMessage(w), "interval_coverage_90", fixed = TRUE)
 
   # expect a failure with the regular wis wihtout ma.rm=TRUE
   expect_warning(
@@ -399,7 +398,7 @@ test_that("score() works even if only some quantiles are missing", {
   expect_message(
     expect_warning(
       score(test),
-      "Computation for `ae_median` failed."
+      "Computation failed for"
     ),
     "interpolating median from the two innermost quantiles"
   )


### PR DESCRIPTION
## Summary
- When multiple metrics fail during `score()`, `apply_metrics()` now collects all errors and emits a **single batched `cli_warn()`** summarizing all failures, instead of warning separately for each failed metric
- `run_safely()` no longer calls `cli_warn()` directly — it returns error info as a structured list, and `apply_metrics()` handles the aggregated warning
- Fixes #811

## Root cause
`run_safely()` called `cli_warn()` immediately inside the `lapply` loop for each metric that failed. With N failing metrics, users saw N separate warnings with no clear summary.

## What the fix does
1. **`run_safely()`** now returns `list(result = NULL, error = <message>)` on failure instead of warning
2. **`apply_metrics()`** collects all failures during the loop, then emits a single `cli_warn()` at the end listing all failed metrics and their error messages
3. Existing tests in `test-class-forecast-quantile.R` updated to match the new warning format

## Test coverage added
- `apply_metrics()` emits a single batched warning when multiple metrics fail
- `apply_metrics()` emits no warning when all metrics succeed
- Batched warning message includes metric name and error details for each failure
- `score()` emits a single batched warning when multiple metrics fail
- `run_safely()` returns error info instead of warning directly
- Existing one-sample `score()` test updated for new format
- Full test suite passes (706 tests), R CMD check: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)