### PR TITLE
BOT: Fix #718: Reset rlang warning verbosity in repeated test runs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,6 +67,7 @@ Suggests:
     ggdist,
     kableExtra,
     knitr,
+    rlang,
     rmarkdown,
     testthat (>= 3.1.9),
     vdiffr

--- a/tests/testthat/test-metrics-interval-range.R
+++ b/tests/testthat/test-metrics-interval-range.R
@@ -20,9 +20,21 @@ test_that("assert_input_interval() works as expected", {
   )
 
   # expect warning if interval range is < 1
+  rlang::reset_warning_verbosity("small_interval_range")
   expect_warning(
     assert_input_interval(observed, lower, upper, 0.5),
     "Found interval ranges between 0 and 1. Are you sure that's right?"
+  )
+})
+
+
+test_that("assert_input_interval() warns about small interval_range on repeated calls", {
+  rlang::reset_warning_verbosity("small_interval_range")
+  suppressWarnings(assert_input_interval(observed, lower, upper, 0.5))
+  rlang::reset_warning_verbosity("small_interval_range")
+  expect_warning(
+    assert_input_interval(observed, lower, upper, 0.5),
+    "Found interval ranges between 0 and 1"
   )
 })
 


### PR DESCRIPTION
## Summary
- Fixes #718: Tests fail locally when `devtools::test()` is run repeatedly in the same R session
- Root cause: `cli_warn(.frequency = "once", .frequency_id = "small_interval_range")` in `assert_input_interval()` suppresses warnings after first emission per R session, causing `expect_warning()` to fail on subsequent runs
- Fix: Add `rlang::reset_warning_verbosity("small_interval_range")` before `expect_warning()` calls to reset the one-time warning gate
- Add `rlang` to `Suggests` in DESCRIPTION (needed for `rlang::reset_warning_verbosity()` in tests)
- Add a new test confirming the warning fires reliably even after being previously consumed and reset

## Test plan
- [x] New test `assert_input_interval() warns about small interval_range on repeated calls` passes
- [x] Existing test for small interval_range warning passes (with reset added)
- [x] Full test suite passes (679 tests, 0 failures)
- [x] R CMD check: 0 errors, 0 warnings, 2 notes (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)