### PR TITLE
BOT: Fix #382: Warn when metric names clash with existing column names

### DIFF
--- a/R/score.R
+++ b/R/score.R
@@ -150,6 +150,19 @@ score.default <- function(forecast, metrics, ...) {
 #' @returns A data table with the forecasts and the calculated metrics.
 #' @keywords internal
 apply_metrics <- function(forecast, metrics, ...) {
+  clashing <- intersect(names(metrics), colnames(forecast))
+  if (length(clashing) > 0) {
+    #nolint start: keyword_quote_linter
+    cli_warn(
+      c(
+        "!" = "Column names {.val {clashing}} are already present in the
+        forecast data and will be overwritten by metric output.",
+        "i" = "Consider renaming these metrics to avoid clashing with
+        existing column names."
+      )
+    )
+    #nolint end
+  }
   lapply(names(metrics), function(metric_name) {
     result <- do.call(
       run_safely,


### PR DESCRIPTION
## Summary
- Fixes #382
- Adds a check in `apply_metrics()` that warns when metric names match existing column names in the forecast data, which would cause silent data overwriting
- Previously, `apply_metrics()` would silently overwrite forecast columns (including forecast unit columns like `horizon`, `model`, or even protected columns like `observed`) when a user-provided metric had the same name

## Root Cause
`apply_metrics()` assigns metric results to the forecast data.table using `forecast[, (metric_name) := result]`. If `metric_name` matches an existing column, that column is silently overwritten, corrupting the forecast data with no warning.

## What the fix does
Adds an `intersect(names(metrics), colnames(forecast))` check at the top of `apply_metrics()` that emits a `cli_warn()` listing all clashing column names. The warning is informational — scoring still proceeds. This single check covers all 7 forecast types since they all call `apply_metrics()`.

## Test coverage added
7 new tests in `test-score.R`:
- Clash detection for binary, quantile, sample, and point forecast types
- No false-positive warning when metrics don't clash
- Multiple simultaneous clashes reported in a single warning
- Protected column name (`observed`) clash detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)