### PR TITLE
Fix assert_forecast_type actual parameter for multivariate sample

### DIFF
--- a/R/class-forecast-multivariate-sample.R
+++ b/R/class-forecast-multivariate-sample.R
@@ -118,7 +118,7 @@ assert_forecast.forecast_multivariate_sample <- function(
 
   assert_forecast_type(
     forecast,
-    actual = "forecast_multivariate_sample",
+    actual = "multivariate_sample",
     desired = forecast_type
   )
   return(invisible(NULL))

--- a/tests/testthat/test-class-forecast-multivariate-sample.R
+++ b/tests/testthat/test-class-forecast-multivariate-sample.R
@@ -464,3 +464,17 @@ test_that(
     )
   }
 )
+
+test_that("assert_forecast() accepts correct forecast_type for multivariate sample", {
+  # The type string used in assert_forecast_type(actual=...) must match
+  # what get_forecast_type() returns (i.e. the class name with the
+  # "forecast_" prefix stripped). Passing the correct type should not error.
+  expect_no_error(
+    suppressMessages(
+      assert_forecast(
+        example_multivariate_sample,
+        forecast_type = "multivariate_sample"
+      )
+    )
+  )
+})


### PR DESCRIPTION
## Summary
- Fixes `assert_forecast.forecast_multivariate_sample` passing `"forecast_multivariate_sample"` (the full class name) instead of `"multivariate_sample"` (the short type name) to `assert_forecast_type(actual = ...)`
- All other forecast types pass the short name (e.g. `"sample"`, `"quantile"`, `"binary"`, `"multivariate_point"`), so this was an inconsistency introduced in #1072

**Bug:** `assert_forecast(data, forecast_type = "multivariate_sample")` would error with:
> Forecast type determined by scoringutils based on input: "forecast_multivariate_sample".
> Desired forecast type: "multivariate_sample".

even though `"multivariate_sample"` is the correct type string returned by `get_forecast_type()`.

## Test plan
- [x] Added test that calls `assert_forecast(data, forecast_type = "multivariate_sample")` — fails before fix, passes after
- [x] Full test suite passes: 735 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)