### PR TITLE
Use latest pandoc in render-readme workflow

### DIFF
--- a/.github/workflows/render_readme.yaml
+++ b/.github/workflows/render_readme.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Setup pandoc
         uses: r-lib/actions/setup-pandoc@v2
+        with:
+          pandoc-version: 'latest'
 
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2


### PR DESCRIPTION
CLAUDE: ## Summary
- Pin `r-lib/actions/setup-pandoc@v2` to `pandoc-version: 'latest'` in the render-readme workflow.

## Why
The default pandoc that ships with `setup-pandoc@v2` is 3.1.11. That version renders consecutive HTML comments without separating blank lines, but pandoc 3.9.x (current Homebrew) inserts blank lines between them when emitting GFM. Concretely, the all-contributors block in `README.Rmd`:

\`\`\`
<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable -->
\`\`\`

renders to stacked comments under CI but to blank-line-separated comments under recent local pandoc. Anytime a locally-rendered `README.md` lands on main (e.g. commit d109d3f0 bundled one alongside an Rbuildignore edit), the next CI render produces a diff and opens an "Update README" PR (e.g. #1173, #1165) that just removes those blank lines. Bumping CI to `latest` ends the cycle for any reasonably current local install.

## Test plan
- [ ] Workflow YAML still parses (GitHub Actions check on this PR)
- [ ] After merge: confirm next render-readme run on main does not produce a no-op "Update README" PR