### PR TITLE
Fix duplicate column names from summarise_scores() with empty metrics (#1179)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # scoringutils (development version)
 
 - Added `plot_discrimination()` to visualise the discrimination ability of binary forecasts by plotting the distribution of predicted probabilities, stratified by the observed outcome. The function requires a `forecast_binary` object (created with `as_forecast_binary()`) (#942).
+- Fixed `summarise_scores()` producing a data.table with duplicate column names when the input `scores` object had no score columns (e.g. because every metric in `score()` warned and returned nothing). `summarise_scores()` now matches metric columns by exact name rather than regex partial match, and errors with a clear message when there is nothing to summarise (#1179).
 - Added internal S3 generic `get_forecast_type_ids()` so each forecast type declares the columns (beyond the forecast unit) that identify a unique row. `get_duplicate_forecasts()` now uses this instead of hard-coded column names (#888).
 - Removed the deprecated vignettes `Deprecated-functions` and `Deprecated-visualisations`. The code for removed functions (`plot_predictions()`, `make_NA()`, `plot_ranges()`, `plot_score_table()`, `merge_pred_and_obs()`) can still be found in the [git history](https://github.com/epiforecasts/scoringutils/tree/d0cd8e2/vignettes) (#1158).
 

--- a/R/summarise_scores.R
+++ b/R/summarise_scores.R
@@ -46,6 +46,7 @@
 #' @export
 #' @importFrom checkmate assert_subset assert_function test_subset
 #'   assert_data_frame
+#' @importFrom cli cli_abort
 #' @keywords scoring
 
 summarise_scores <- function(scores,
@@ -59,11 +60,23 @@ summarise_scores <- function(scores,
   assert_function(fun)
 
   metrics <- get_metrics.scores(scores, error = TRUE)
+  metric_cols <- intersect(colnames(scores), metrics)
+  if (length(metric_cols) == 0) {
+    cli_abort(
+      c(
+        `!` = "No score columns to summarise.",
+        i = "The {.cls scores} object has no columns matching its
+             {.code metrics} attribute. This usually means every metric
+             passed to {.fn score} failed (e.g. warned and returned no
+             values)."
+      )
+    )
+  }
 
   # summarise scores -----------------------------------------------------------
   scores <- scores[, lapply(.SD, fun, ...),
     by = c(by),
-    .SDcols = colnames(scores) %like% paste(metrics, collapse = "|")
+    .SDcols = metric_cols
   ]
 
   attr(scores, "metrics") <- metrics

--- a/tests/testthat/test-summarise_scores.R
+++ b/tests/testthat/test-summarise_scores.R
@@ -71,3 +71,29 @@ test_that("summarise_scores() errors if `by = NULL", {
     "Assertion on 'by' failed: Must be a subset of"
   )
 })
+
+test_that("summarise_scores() errors if there are no score columns", {
+  # mimics the situation in which every metric passed to `score()` failed:
+  # `scores` carries an empty `metrics` attribute, so there is nothing to
+  # summarise. Previously this silently produced a data.table with a
+  # duplicate `by` column (gh #1179).
+  empty_scores <- data.table::copy(scores_quantile)
+  metric_cols <- attr(empty_scores, "metrics")
+  empty_scores[, (metric_cols) := NULL]
+  attr(empty_scores, "metrics") <- character(0)
+
+  expect_error(
+    summarise_scores(empty_scores, by = "model"),
+    "No score columns to summarise"
+  )
+})
+
+test_that("summarise_scores() does not partial-match metric names", {
+  # ensures we use exact column matching rather than regex partial matching:
+  # a metric named e.g. "wis" should not pull in a column called
+  # "wis_something_else" that happens to share a prefix.
+  test <- data.table::copy(scores_quantile)
+  test[, wis_extra := 0]
+  result <- summarise_scores(test, by = "model")
+  expect_false("wis_extra" %in% colnames(result))
+})

--- a/tests/testthat/test-summarise_scores.R
+++ b/tests/testthat/test-summarise_scores.R
@@ -88,6 +88,30 @@ test_that("summarise_scores() errors if there are no score columns", {
   )
 })
 
+test_that("summarise_scores() errors on the empty-metrics reprex (#1179)", {
+  # end-to-end version of the issue reprex: the 55% interval requires the
+  # 0.225 and 0.775 quantiles, which are absent from `example_quantile`, so
+  # the only metric warns and produces no score columns. `summarise_scores()`
+  # should then error rather than return a data.table with a duplicate `by`
+  # column (gh #1179).
+  fc <- as_forecast_quantile(example_quantile)
+  expect_warning(
+    sc <- score(fc, metrics = list(
+      interval_coverage_55 = purrr::partial(
+        interval_coverage,
+        interval_range = 55
+      )
+    )),
+    "interval coverage"
+  )
+  expect_length(intersect(colnames(sc), attr(sc, "metrics")), 0)
+
+  expect_error(
+    summarise_scores(sc, by = "model"),
+    "No score columns to summarise"
+  )
+})
+
 test_that("summarise_scores() does not partial-match metric names", {
   # ensures we use exact column matching rather than regex partial matching:
   # a metric named e.g. "wis" should not pull in a column called


### PR DESCRIPTION
CLAUDE: Closes #1179.

## Summary
- `summarise_scores()` previously selected which columns to summarise via `colnames(scores) %like% paste(metrics, collapse = "|")`. When the `metrics` attribute is `character(0)` (i.e. every metric in `score()` warned and returned nothing), this pattern becomes the empty string, which `%like%` matches against every column — including the `by` column. The `by` column was then passed to the summary function, producing the spurious "argument is not numeric or logical" warning and a data.table with a duplicate `by` column. The duplicate is invisible inside data.table but breaks downstream conversion to tibble.
- Switched to exact column-name matching via `intersect(colnames(scores), metrics)`. This also incidentally fixes a latent issue where a metric named e.g. "wis" would have matched any column whose name contained "wis" (such as "wis_relative_skill").

## Both tightenings from #1179 are implemented
The issue suggested two fixes (either or both); this PR does both:
1. **`summarise_scores()` no longer summarises its `by` columns.** With exact-name matching, `.SDcols` is now `intersect(colnames(scores), metrics)`, so task-ID columns (including the `by` column) are never passed to the summary function. This removes the duplicate-column root cause.
2. **`summarise_scores()` errors early when there are no score columns to summarise.** When `intersect(colnames(scores), metrics)` is empty there is nothing meaningful to return, so it now aborts with a clear message rather than producing a malformed object.

## Tests
- End-to-end regression test for the issue reprex: scoring `example_quantile` with only `interval_coverage_55` warns and produces no score columns, after which `summarise_scores()` errors.
- A unit-level test of the same empty-metrics case (manually cleared score columns).
- A test guarding against partial-name matching.

## Out of scope
The issue also raises whether `score()` should itself fail (rather than return an empty scores object) when every metric fails. That's a real question but a bigger design call; leaving it for a separate discussion.

## Test plan
- [x] Targeted tests pass locally (`testthat::test_file("tests/testthat/test-summarise_scores.R")` — 16 pass)
- [x] `lintr::lint()` clean on changed files
- [ ] CI green (full `R CMD check` / `covr` relied on CI)
- Branch rebased onto current `main`, which also picks up the multivariate-sample snapshot fix (#1182) so macOS CI should be green.

This was opened by a bot. Please ping @seabbs for any questions.
